### PR TITLE
fix(slider): snapback when local changes race SSE

### DIFF
--- a/Sources/HueBar/Services/EventStreamUpdater.swift
+++ b/Sources/HueBar/Services/EventStreamUpdater.swift
@@ -3,26 +3,36 @@ import Foundation
 enum EventStreamUpdater {
     static func apply(_ event: HueEventResource, to groupedLights: inout [GroupedLight]) {
         guard let index = groupedLights.firstIndex(where: { $0.id == event.id }) else { return }
-        let existing = groupedLights[index]
-        groupedLights[index] = GroupedLight(
-            id: existing.id,
-            on: event.on ?? existing.on,
-            dimming: event.dimming ?? existing.dimming,
-            colorTemperature: existing.colorTemperature
-        )
+        if let on = event.on {
+            groupedLights[index].on = on
+        }
+        if let dimming = event.dimming {
+            groupedLights[index].dimming = dimming
+        }
+        if let colorTemperature = event.colorTemperature {
+            groupedLights[index].colorTemperature = LightColorTemperature(
+                mirek: colorTemperature.mirek,
+                mirekValid: colorTemperature.mirekValid
+            )
+        }
     }
 
     static func apply(_ event: HueEventResource, to lights: inout [HueLight]) {
         guard let index = lights.firstIndex(where: { $0.id == event.id }) else { return }
-        let existing = lights[index]
-        lights[index] = HueLight(
-            id: existing.id,
-            owner: existing.owner,
-            metadata: existing.metadata,
-            on: event.on ?? existing.on,
-            dimming: event.dimming ?? existing.dimming,
-            color: event.color.map { LightColor(xy: $0.xy) } ?? existing.color,
-            colorTemperature: event.colorTemperature.map { LightColorTemperature(mirek: $0.mirek, mirekValid: $0.mirekValid) } ?? existing.colorTemperature
-        )
+        if let on = event.on {
+            lights[index].on = on
+        }
+        if let dimming = event.dimming {
+            lights[index].dimming = dimming
+        }
+        if let color = event.color {
+            lights[index].color = LightColor(xy: color.xy)
+        }
+        if let colorTemperature = event.colorTemperature {
+            lights[index].colorTemperature = LightColorTemperature(
+                mirek: colorTemperature.mirek,
+                mirekValid: colorTemperature.mirekValid
+            )
+        }
     }
 }

--- a/Sources/HueBar/Services/HueAPIClient.swift
+++ b/Sources/HueBar/Services/HueAPIClient.swift
@@ -140,11 +140,6 @@ final class HueAPIClient {
         try await fetch(path: "light")
     }
 
-    func previewLightOn(id: String, on: Bool) {
-        guard Self.isValidResourceId(id) else { return }
-        applyLightOnOptimistically(id: id, on: on)
-    }
-
     /// Toggle an individual light on/off
     func toggleLight(id: String, on: Bool) async throws {
         guard Self.isValidResourceId(id) else {
@@ -253,11 +248,6 @@ final class HueAPIClient {
     /// Validate that a resource ID matches the expected Hue API UUID format
     private static func isValidResourceId(_ id: String) -> Bool {
         UUID(uuidString: id) != nil
-    }
-
-    func previewGroupedLightOn(id: String, on: Bool) {
-        guard Self.isValidResourceId(id) else { return }
-        applyGroupedLightOnOptimistically(id: id, on: on)
     }
 
     /// Toggle a grouped light on/off

--- a/Sources/HueBar/Services/HueAPIClient.swift
+++ b/Sources/HueBar/Services/HueAPIClient.swift
@@ -140,15 +140,17 @@ final class HueAPIClient {
         try await fetch(path: "light")
     }
 
+    func previewLightOn(id: String, on: Bool) {
+        guard Self.isValidResourceId(id) else { return }
+        applyLightOnOptimistically(id: id, on: on)
+    }
+
     /// Toggle an individual light on/off
     func toggleLight(id: String, on: Bool) async throws {
         guard Self.isValidResourceId(id) else {
             throw HueAPIError.invalidResourceId
         }
-        // Optimistic update
-        if let index = lights.firstIndex(where: { $0.id == id }) {
-            lights[index].on = OnState(on: on)
-        }
+        applyLightOnOptimistically(id: id, on: on)
 
         let request = try makeRequest(
             path: "light/\(id)",
@@ -158,9 +160,15 @@ final class HueAPIClient {
         let (_, response) = try await session.data(for: request)
         guard let httpResponse = response as? HTTPURLResponse,
               (200...299).contains(httpResponse.statusCode) else {
+            optimisticUpdates.clearLightOn(id: id)
             lights = try await fetchLights()
             throw HueAPIError.invalidResponse
         }
+    }
+
+    func previewLightBrightness(id: String, brightness: Double) {
+        guard Self.isValidResourceId(id) else { return }
+        applyLightBrightnessOptimistically(id: id, brightness: brightness)
     }
 
     /// Set brightness for an individual light (0.0–100.0)
@@ -168,11 +176,7 @@ final class HueAPIClient {
         guard Self.isValidResourceId(id) else {
             throw HueAPIError.invalidResourceId
         }
-        let clamped = min(max(brightness, 0.0), 100.0)
-
-        if let index = lights.firstIndex(where: { $0.id == id }) {
-            lights[index].dimming = DimmingState(brightness: clamped)
-        }
+        let clamped = applyLightBrightnessOptimistically(id: id, brightness: brightness)
 
         let request = try makeRequest(
             path: "light/\(id)",
@@ -182,9 +186,15 @@ final class HueAPIClient {
         let (_, response) = try await session.data(for: request)
         guard let httpResponse = response as? HTTPURLResponse,
               (200...299).contains(httpResponse.statusCode) else {
+            optimisticUpdates.clearLightBrightness(id: id)
             lights = try await fetchLights()
             throw HueAPIError.invalidResponse
         }
+    }
+
+    func previewLightColor(id: String, xy: CIEXYColor) {
+        guard Self.isValidResourceId(id) else { return }
+        applyLightColorOptimistically(id: id, xy: xy)
     }
 
     /// Set color for an individual light using CIE xy coordinates
@@ -192,20 +202,22 @@ final class HueAPIClient {
         guard Self.isValidResourceId(id) else {
             throw HueAPIError.invalidResourceId
         }
-
-        // Optimistic update
-        if let index = lights.firstIndex(where: { $0.id == id }) {
-            lights[index].color = LightColor(xy: xy)
-        }
+        applyLightColorOptimistically(id: id, xy: xy)
 
         let body = try JSONEncoder().encode(["color": ["xy": ["x": xy.x, "y": xy.y]]])
         let request = try makeRequest(path: "light/\(id)", method: "PUT", body: body)
         let (_, response) = try await session.data(for: request)
         guard let httpResponse = response as? HTTPURLResponse,
               (200...299).contains(httpResponse.statusCode) else {
+            optimisticUpdates.clearLightColor(id: id)
             lights = try await fetchLights()
             throw HueAPIError.invalidResponse
         }
+    }
+
+    func previewLightColorTemperature(id: String, mirek: Int) {
+        guard Self.isValidResourceId(id) else { return }
+        applyLightColorTemperatureOptimistically(id: id, mirek: mirek)
     }
 
     /// Set color temperature for an individual light (mirek value: 153–500)
@@ -213,18 +225,14 @@ final class HueAPIClient {
         guard Self.isValidResourceId(id) else {
             throw HueAPIError.invalidResourceId
         }
-        let clampedMirek = min(max(mirek, 153), 500)
-
-        // Optimistic update
-        if let index = lights.firstIndex(where: { $0.id == id }) {
-            lights[index].colorTemperature = LightColorTemperature(mirek: clampedMirek, mirekValid: true)
-        }
+        let clampedMirek = applyLightColorTemperatureOptimistically(id: id, mirek: mirek)
 
         let body = try JSONEncoder().encode(["color_temperature": ["mirek": clampedMirek]])
         let request = try makeRequest(path: "light/\(id)", method: "PUT", body: body)
         let (_, response) = try await session.data(for: request)
         guard let httpResponse = response as? HTTPURLResponse,
               (200...299).contains(httpResponse.statusCode) else {
+            optimisticUpdates.clearLightColorTemperature(id: id)
             lights = try await fetchLights()
             throw HueAPIError.invalidResponse
         }
@@ -247,15 +255,17 @@ final class HueAPIClient {
         UUID(uuidString: id) != nil
     }
 
+    func previewGroupedLightOn(id: String, on: Bool) {
+        guard Self.isValidResourceId(id) else { return }
+        applyGroupedLightOnOptimistically(id: id, on: on)
+    }
+
     /// Toggle a grouped light on/off
     func toggleGroupedLight(id: String, on: Bool) async throws {
         guard Self.isValidResourceId(id) else {
             throw HueAPIError.invalidResourceId
         }
-        // Optimistically update local state so the toggle reflects immediately
-        if let index = groupedLights.firstIndex(where: { $0.id == id }) {
-            groupedLights[index].on = OnState(on: on)
-        }
+        applyGroupedLightOnOptimistically(id: id, on: on)
 
         let request = try makeRequest(
             path: "grouped_light/\(id)",
@@ -266,9 +276,15 @@ final class HueAPIClient {
         guard let httpResponse = response as? HTTPURLResponse,
               (200...299).contains(httpResponse.statusCode) else {
             // Revert on failure
+            optimisticUpdates.clearGroupedLightOn(id: id)
             groupedLights = try await fetchGroupedLights()
             throw HueAPIError.invalidResponse
         }
+    }
+
+    func previewBrightness(groupedLightId: String, brightness: Double) {
+        guard Self.isValidResourceId(groupedLightId) else { return }
+        applyGroupedLightBrightnessOptimistically(id: groupedLightId, brightness: brightness)
     }
 
     /// Set brightness for a grouped light (0.0–100.0)
@@ -276,12 +292,7 @@ final class HueAPIClient {
         guard Self.isValidResourceId(groupedLightId) else {
             throw HueAPIError.invalidResourceId
         }
-        let clampedBrightness = min(max(brightness, 0.0), 100.0)
-
-        // Optimistic update
-        if let index = groupedLights.firstIndex(where: { $0.id == groupedLightId }) {
-            groupedLights[index].dimming = DimmingState(brightness: clampedBrightness)
-        }
+        let clampedBrightness = applyGroupedLightBrightnessOptimistically(id: groupedLightId, brightness: brightness)
 
         let request = try makeRequest(
             path: "grouped_light/\(groupedLightId)",
@@ -292,9 +303,15 @@ final class HueAPIClient {
         guard let httpResponse = response as? HTTPURLResponse,
               (200...299).contains(httpResponse.statusCode) else {
             // Revert on failure
+            optimisticUpdates.clearGroupedLightBrightness(id: groupedLightId)
             groupedLights = try await fetchGroupedLights()
             throw HueAPIError.invalidResponse
         }
+    }
+
+    func previewGroupedLightColorTemperature(id: String, mirek: Int) {
+        guard Self.isValidResourceId(id) else { return }
+        applyGroupedLightColorTemperatureOptimistically(id: id, mirek: mirek)
     }
 
     /// Set color temperature for a grouped light (153–500 mirek)
@@ -302,17 +319,14 @@ final class HueAPIClient {
         guard Self.isValidResourceId(id) else {
             throw HueAPIError.invalidResourceId
         }
-        let clamped = min(max(mirek, 153), 500)
-
-        if let index = groupedLights.firstIndex(where: { $0.id == id }) {
-            groupedLights[index].colorTemperature = LightColorTemperature(mirek: clamped, mirekValid: true)
-        }
+        let clamped = applyGroupedLightColorTemperatureOptimistically(id: id, mirek: mirek)
 
         let body = try JSONEncoder().encode(["color_temperature": ["mirek": clamped]])
         let request = try makeRequest(path: "grouped_light/\(id)", method: "PUT", body: body)
         let (_, response) = try await session.data(for: request)
         guard let httpResponse = response as? HTTPURLResponse,
               (200...299).contains(httpResponse.statusCode) else {
+            optimisticUpdates.clearGroupedLightColorTemperature(id: id)
             groupedLights = try await fetchGroupedLights()
             throw HueAPIError.invalidResponse
         }
@@ -440,6 +454,7 @@ final class HueAPIClient {
     private var eventStreamConnection: EventStreamConnection?
     private var eventConsumingTask: Task<Void, Never>?
     private var refreshDebounceTask: Task<Void, Never>?
+    private var optimisticUpdates = OptimisticUpdateTracker()
 
     func startEventStream() {
         guard eventConsumingTask == nil else { return }
@@ -468,6 +483,10 @@ final class HueAPIClient {
         refreshDebounceTask = nil
     }
 
+    func applyEventsForTesting(_ events: [HueEvent]) {
+        applyEvents(events)
+    }
+
     private func applyEvents(_ events: [HueEvent]) {
         for event in events {
             switch event.type {
@@ -475,9 +494,11 @@ final class HueAPIClient {
                 for resource in event.data {
                     switch resource.type {
                     case "grouped_light":
-                        EventStreamUpdater.apply(resource, to: &groupedLights)
+                        let filteredResource = optimisticUpdates.filter(resource, kind: .groupedLight)
+                        EventStreamUpdater.apply(filteredResource, to: &groupedLights)
                     case "light":
-                        EventStreamUpdater.apply(resource, to: &lights)
+                        let filteredResource = optimisticUpdates.filter(resource, kind: .light)
+                        EventStreamUpdater.apply(filteredResource, to: &lights)
                     case "scene":
                         if let status = resource.status?.active,
                            let resourceStatus = resource.status {
@@ -528,6 +549,75 @@ final class HueAPIClient {
     func moveZoneToBottom(_ id: String) { orderManager.moveZoneToBottom(id: id, zones: &zones) }
 
     // MARK: - Private
+
+    private func applyLightOnOptimistically(id: String, on: Bool) {
+        optimisticUpdates.recordLightOn(id: id, on: on)
+        if let index = lights.firstIndex(where: { $0.id == id }) {
+            lights[index].on = OnState(on: on)
+        }
+    }
+
+    @discardableResult
+    private func applyLightBrightnessOptimistically(id: String, brightness: Double) -> Double {
+        let clamped = clampBrightness(brightness)
+        optimisticUpdates.recordLightBrightness(id: id, brightness: clamped)
+        if let index = lights.firstIndex(where: { $0.id == id }) {
+            lights[index].dimming = DimmingState(brightness: clamped)
+        }
+        return clamped
+    }
+
+    private func applyLightColorOptimistically(id: String, xy: CIEXYColor) {
+        optimisticUpdates.recordLightColor(id: id, xy: xy)
+        if let index = lights.firstIndex(where: { $0.id == id }) {
+            lights[index].color = LightColor(xy: xy)
+        }
+    }
+
+    @discardableResult
+    private func applyLightColorTemperatureOptimistically(id: String, mirek: Int) -> Int {
+        let clamped = clampMirek(mirek)
+        optimisticUpdates.recordLightColorTemperature(id: id, mirek: clamped)
+        if let index = lights.firstIndex(where: { $0.id == id }) {
+            lights[index].colorTemperature = LightColorTemperature(mirek: clamped, mirekValid: true)
+        }
+        return clamped
+    }
+
+    private func applyGroupedLightOnOptimistically(id: String, on: Bool) {
+        optimisticUpdates.recordGroupedLightOn(id: id, on: on)
+        if let index = groupedLights.firstIndex(where: { $0.id == id }) {
+            groupedLights[index].on = OnState(on: on)
+        }
+    }
+
+    @discardableResult
+    private func applyGroupedLightBrightnessOptimistically(id: String, brightness: Double) -> Double {
+        let clamped = clampBrightness(brightness)
+        optimisticUpdates.recordGroupedLightBrightness(id: id, brightness: clamped)
+        if let index = groupedLights.firstIndex(where: { $0.id == id }) {
+            groupedLights[index].dimming = DimmingState(brightness: clamped)
+        }
+        return clamped
+    }
+
+    @discardableResult
+    private func applyGroupedLightColorTemperatureOptimistically(id: String, mirek: Int) -> Int {
+        let clamped = clampMirek(mirek)
+        optimisticUpdates.recordGroupedLightColorTemperature(id: id, mirek: clamped)
+        if let index = groupedLights.firstIndex(where: { $0.id == id }) {
+            groupedLights[index].colorTemperature = LightColorTemperature(mirek: clamped, mirekValid: true)
+        }
+        return clamped
+    }
+
+    private func clampBrightness(_ brightness: Double) -> Double {
+        min(max(brightness, 0.0), 100.0)
+    }
+
+    private func clampMirek(_ mirek: Int) -> Int {
+        min(max(mirek, 153), 500)
+    }
 
     private func makeRequest(path: String, method: String = "GET", body: Data? = nil) throws -> URLRequest {
         var components = URLComponents()

--- a/Sources/HueBar/Services/HueAPIClient.swift
+++ b/Sources/HueBar/Services/HueAPIClient.swift
@@ -160,7 +160,7 @@ final class HueAPIClient {
         let (_, response) = try await session.data(for: request)
         guard let httpResponse = response as? HTTPURLResponse,
               (200...299).contains(httpResponse.statusCode) else {
-            optimisticUpdates.clearLightOn(id: id)
+            optimisticUpdates.clear(.on, for: .light, id: id)
             lights = try await fetchLights()
             throw HueAPIError.invalidResponse
         }
@@ -186,7 +186,7 @@ final class HueAPIClient {
         let (_, response) = try await session.data(for: request)
         guard let httpResponse = response as? HTTPURLResponse,
               (200...299).contains(httpResponse.statusCode) else {
-            optimisticUpdates.clearLightBrightness(id: id)
+            optimisticUpdates.clear(.brightness, for: .light, id: id)
             lights = try await fetchLights()
             throw HueAPIError.invalidResponse
         }
@@ -209,7 +209,7 @@ final class HueAPIClient {
         let (_, response) = try await session.data(for: request)
         guard let httpResponse = response as? HTTPURLResponse,
               (200...299).contains(httpResponse.statusCode) else {
-            optimisticUpdates.clearLightColor(id: id)
+            optimisticUpdates.clear(.color, for: .light, id: id)
             lights = try await fetchLights()
             throw HueAPIError.invalidResponse
         }
@@ -232,7 +232,7 @@ final class HueAPIClient {
         let (_, response) = try await session.data(for: request)
         guard let httpResponse = response as? HTTPURLResponse,
               (200...299).contains(httpResponse.statusCode) else {
-            optimisticUpdates.clearLightColorTemperature(id: id)
+            optimisticUpdates.clear(.colorTemperature, for: .light, id: id)
             lights = try await fetchLights()
             throw HueAPIError.invalidResponse
         }
@@ -276,7 +276,7 @@ final class HueAPIClient {
         guard let httpResponse = response as? HTTPURLResponse,
               (200...299).contains(httpResponse.statusCode) else {
             // Revert on failure
-            optimisticUpdates.clearGroupedLightOn(id: id)
+            optimisticUpdates.clear(.on, for: .groupedLight, id: id)
             groupedLights = try await fetchGroupedLights()
             throw HueAPIError.invalidResponse
         }
@@ -303,7 +303,7 @@ final class HueAPIClient {
         guard let httpResponse = response as? HTTPURLResponse,
               (200...299).contains(httpResponse.statusCode) else {
             // Revert on failure
-            optimisticUpdates.clearGroupedLightBrightness(id: groupedLightId)
+            optimisticUpdates.clear(.brightness, for: .groupedLight, id: groupedLightId)
             groupedLights = try await fetchGroupedLights()
             throw HueAPIError.invalidResponse
         }
@@ -326,7 +326,7 @@ final class HueAPIClient {
         let (_, response) = try await session.data(for: request)
         guard let httpResponse = response as? HTTPURLResponse,
               (200...299).contains(httpResponse.statusCode) else {
-            optimisticUpdates.clearGroupedLightColorTemperature(id: id)
+            optimisticUpdates.clear(.colorTemperature, for: .groupedLight, id: id)
             groupedLights = try await fetchGroupedLights()
             throw HueAPIError.invalidResponse
         }
@@ -551,7 +551,7 @@ final class HueAPIClient {
     // MARK: - Private
 
     private func applyLightOnOptimistically(id: String, on: Bool) {
-        optimisticUpdates.recordLightOn(id: id, on: on)
+        optimisticUpdates.record(.on(on), for: .light, id: id)
         if let index = lights.firstIndex(where: { $0.id == id }) {
             lights[index].on = OnState(on: on)
         }
@@ -560,7 +560,7 @@ final class HueAPIClient {
     @discardableResult
     private func applyLightBrightnessOptimistically(id: String, brightness: Double) -> Double {
         let clamped = clampBrightness(brightness)
-        optimisticUpdates.recordLightBrightness(id: id, brightness: clamped)
+        optimisticUpdates.record(.brightness(clamped), for: .light, id: id)
         if let index = lights.firstIndex(where: { $0.id == id }) {
             lights[index].dimming = DimmingState(brightness: clamped)
         }
@@ -568,7 +568,7 @@ final class HueAPIClient {
     }
 
     private func applyLightColorOptimistically(id: String, xy: CIEXYColor) {
-        optimisticUpdates.recordLightColor(id: id, xy: xy)
+        optimisticUpdates.record(.color(xy), for: .light, id: id)
         if let index = lights.firstIndex(where: { $0.id == id }) {
             lights[index].color = LightColor(xy: xy)
         }
@@ -577,7 +577,7 @@ final class HueAPIClient {
     @discardableResult
     private func applyLightColorTemperatureOptimistically(id: String, mirek: Int) -> Int {
         let clamped = clampMirek(mirek)
-        optimisticUpdates.recordLightColorTemperature(id: id, mirek: clamped)
+        optimisticUpdates.record(.colorTemperature(clamped), for: .light, id: id)
         if let index = lights.firstIndex(where: { $0.id == id }) {
             lights[index].colorTemperature = LightColorTemperature(mirek: clamped, mirekValid: true)
         }
@@ -585,7 +585,7 @@ final class HueAPIClient {
     }
 
     private func applyGroupedLightOnOptimistically(id: String, on: Bool) {
-        optimisticUpdates.recordGroupedLightOn(id: id, on: on)
+        optimisticUpdates.record(.on(on), for: .groupedLight, id: id)
         if let index = groupedLights.firstIndex(where: { $0.id == id }) {
             groupedLights[index].on = OnState(on: on)
         }
@@ -594,7 +594,7 @@ final class HueAPIClient {
     @discardableResult
     private func applyGroupedLightBrightnessOptimistically(id: String, brightness: Double) -> Double {
         let clamped = clampBrightness(brightness)
-        optimisticUpdates.recordGroupedLightBrightness(id: id, brightness: clamped)
+        optimisticUpdates.record(.brightness(clamped), for: .groupedLight, id: id)
         if let index = groupedLights.firstIndex(where: { $0.id == id }) {
             groupedLights[index].dimming = DimmingState(brightness: clamped)
         }
@@ -604,7 +604,7 @@ final class HueAPIClient {
     @discardableResult
     private func applyGroupedLightColorTemperatureOptimistically(id: String, mirek: Int) -> Int {
         let clamped = clampMirek(mirek)
-        optimisticUpdates.recordGroupedLightColorTemperature(id: id, mirek: clamped)
+        optimisticUpdates.record(.colorTemperature(clamped), for: .groupedLight, id: id)
         if let index = groupedLights.firstIndex(where: { $0.id == id }) {
             groupedLights[index].colorTemperature = LightColorTemperature(mirek: clamped, mirekValid: true)
         }

--- a/Sources/HueBar/Services/OptimisticUpdateTracker.swift
+++ b/Sources/HueBar/Services/OptimisticUpdateTracker.swift
@@ -158,6 +158,8 @@ struct OptimisticUpdateTracker: Sendable {
     }
 
     private static func brightnessMatches(_ lhs: Double, _ rhs: Double) -> Bool {
+        // Hue stores brightness in 254 internal levels, so values can round-trip
+        // slightly off from the percentage we sent.
         abs(lhs - rhs) <= 0.5
     }
 

--- a/Sources/HueBar/Services/OptimisticUpdateTracker.swift
+++ b/Sources/HueBar/Services/OptimisticUpdateTracker.swift
@@ -1,91 +1,57 @@
 import Foundation
 
 struct OptimisticUpdateTracker: Sendable {
-    enum ResourceKind: Sendable {
+    enum ResourceKind: Sendable, Hashable {
         case groupedLight
         case light
     }
 
+    enum Field: Sendable {
+        case on
+        case brightness
+        case color
+        case colorTemperature
+    }
+
+    enum Value: Sendable {
+        case on(Bool)
+        case brightness(Double)
+        case color(CIEXYColor)
+        case colorTemperature(Int)
+    }
+
     static let protectionWindow: TimeInterval = 3.0
 
-    private var groupedLights: [String: PendingLightUpdate] = [:]
-    private var lights: [String: PendingLightUpdate] = [:]
+    private var updates: [ResourceKey: PendingLightUpdate] = [:]
 
-    mutating func recordGroupedLightOn(id: String, on: Bool, now: Date = Date()) {
-        groupedLights[id, default: PendingLightUpdate()].on = Self.pending(on, now: now)
+    mutating func record(_ value: Value, for kind: ResourceKind, id: String, now: Date = Date()) {
+        let key = ResourceKey(kind: kind, id: id)
+        Self.record(value, in: &updates[key, default: PendingLightUpdate()], now: now)
     }
 
-    mutating func recordGroupedLightBrightness(id: String, brightness: Double, now: Date = Date()) {
-        groupedLights[id, default: PendingLightUpdate()].brightness = Self.pending(brightness, now: now)
-    }
-
-    mutating func recordGroupedLightColorTemperature(id: String, mirek: Int, now: Date = Date()) {
-        groupedLights[id, default: PendingLightUpdate()].colorTemperature = Self.pending(mirek, now: now)
-    }
-
-    mutating func recordLightOn(id: String, on: Bool, now: Date = Date()) {
-        lights[id, default: PendingLightUpdate()].on = Self.pending(on, now: now)
-    }
-
-    mutating func recordLightBrightness(id: String, brightness: Double, now: Date = Date()) {
-        lights[id, default: PendingLightUpdate()].brightness = Self.pending(brightness, now: now)
-    }
-
-    mutating func recordLightColor(id: String, xy: CIEXYColor, now: Date = Date()) {
-        lights[id, default: PendingLightUpdate()].color = Self.pending(xy, now: now)
-    }
-
-    mutating func recordLightColorTemperature(id: String, mirek: Int, now: Date = Date()) {
-        lights[id, default: PendingLightUpdate()].colorTemperature = Self.pending(mirek, now: now)
-    }
-
-    mutating func clearGroupedLightOn(id: String) {
-        Self.clear(id: id, in: &groupedLights) { $0.on = nil }
-    }
-
-    mutating func clearGroupedLightBrightness(id: String) {
-        Self.clear(id: id, in: &groupedLights) { $0.brightness = nil }
-    }
-
-    mutating func clearGroupedLightColorTemperature(id: String) {
-        Self.clear(id: id, in: &groupedLights) { $0.colorTemperature = nil }
-    }
-
-    mutating func clearLightOn(id: String) {
-        Self.clear(id: id, in: &lights) { $0.on = nil }
-    }
-
-    mutating func clearLightBrightness(id: String) {
-        Self.clear(id: id, in: &lights) { $0.brightness = nil }
-    }
-
-    mutating func clearLightColor(id: String) {
-        Self.clear(id: id, in: &lights) { $0.color = nil }
-    }
-
-    mutating func clearLightColorTemperature(id: String) {
-        Self.clear(id: id, in: &lights) { $0.colorTemperature = nil }
-    }
-
-    mutating func filter(_ event: HueEventResource, kind: ResourceKind, now: Date = Date()) -> HueEventResource {
-        switch kind {
-        case .groupedLight:
-            return Self.filter(event, pendingUpdates: &groupedLights, now: now)
-        case .light:
-            return Self.filter(event, pendingUpdates: &lights, now: now)
+    mutating func clear(_ field: Field, for kind: ResourceKind, id: String) {
+        let key = ResourceKey(kind: kind, id: id)
+        guard var pending = updates[key] else { return }
+        Self.clear(field, from: &pending)
+        if pending.isEmpty {
+            updates[key] = nil
+        } else {
+            updates[key] = pending
         }
     }
 
-    private static func pending<Value: Sendable>(_ value: Value, now: Date) -> PendingValue<Value> {
-        PendingValue(value: value, expiresAt: now.addingTimeInterval(Self.protectionWindow))
+    mutating func filter(_ event: HueEventResource, kind: ResourceKind, now: Date = Date()) -> HueEventResource {
+        let key = ResourceKey(kind: kind, id: event.id)
+        return Self.filter(event, key: key, pendingUpdates: &updates, now: now)
     }
 
     private static func filter(
         _ event: HueEventResource,
-        pendingUpdates: inout [String: PendingLightUpdate],
+        key: ResourceKey,
+        pendingUpdates: inout [ResourceKey: PendingLightUpdate],
         now: Date
     ) -> HueEventResource {
-        guard var pending = pendingUpdates[event.id] else { return event }
+        guard var pending = pendingUpdates[key] else { return event }
 
         var on = event.on
         var dimming = event.dimming
@@ -106,9 +72,9 @@ struct OptimisticUpdateTracker: Sendable {
         }
 
         if pending.isEmpty {
-            pendingUpdates[event.id] = nil
+            pendingUpdates[key] = nil
         } else {
-            pendingUpdates[event.id] = pending
+            pendingUpdates[key] = pending
         }
 
         return HueEventResource(
@@ -124,18 +90,34 @@ struct OptimisticUpdateTracker: Sendable {
         )
     }
 
-    private static func clear(
-        id: String,
-        in pendingUpdates: inout [String: PendingLightUpdate],
-        clearField: (inout PendingLightUpdate) -> Void
-    ) {
-        guard var pending = pendingUpdates[id] else { return }
-        clearField(&pending)
-        if pending.isEmpty {
-            pendingUpdates[id] = nil
-        } else {
-            pendingUpdates[id] = pending
+    private static func record(_ value: Value, in pending: inout PendingLightUpdate, now: Date) {
+        switch value {
+        case let .on(on):
+            pending.on = Self.pending(on, now: now)
+        case let .brightness(brightness):
+            pending.brightness = Self.pending(brightness, now: now)
+        case let .color(xy):
+            pending.color = Self.pending(xy, now: now)
+        case let .colorTemperature(mirek):
+            pending.colorTemperature = Self.pending(mirek, now: now)
         }
+    }
+
+    private static func clear(_ field: Field, from pending: inout PendingLightUpdate) {
+        switch field {
+        case .on:
+            pending.on = nil
+        case .brightness:
+            pending.brightness = nil
+        case .color:
+            pending.color = nil
+        case .colorTemperature:
+            pending.colorTemperature = nil
+        }
+    }
+
+    private static func pending<Value: Sendable>(_ value: Value, now: Date) -> PendingValue<Value> {
+        PendingValue(value: value, expiresAt: now.addingTimeInterval(Self.protectionWindow))
     }
 
     private static func filter<EventValue, Pending>(
@@ -166,6 +148,11 @@ struct OptimisticUpdateTracker: Sendable {
     private static func colorMatches(_ lhs: CIEXYColor, _ rhs: CIEXYColor) -> Bool {
         abs(lhs.x - rhs.x) <= 0.0001 && abs(lhs.y - rhs.y) <= 0.0001
     }
+}
+
+private struct ResourceKey: Hashable, Sendable {
+    let kind: OptimisticUpdateTracker.ResourceKind
+    let id: String
 }
 
 private struct PendingLightUpdate: Sendable {

--- a/Sources/HueBar/Services/OptimisticUpdateTracker.swift
+++ b/Sources/HueBar/Services/OptimisticUpdateTracker.swift
@@ -1,0 +1,187 @@
+import Foundation
+
+struct OptimisticUpdateTracker: Sendable {
+    enum ResourceKind: Sendable {
+        case groupedLight
+        case light
+    }
+
+    static let protectionWindow: TimeInterval = 3.0
+
+    private var groupedLights: [String: PendingLightUpdate] = [:]
+    private var lights: [String: PendingLightUpdate] = [:]
+
+    mutating func recordGroupedLightOn(id: String, on: Bool, now: Date = Date()) {
+        groupedLights[id, default: PendingLightUpdate()].on = Self.pending(on, now: now)
+    }
+
+    mutating func recordGroupedLightBrightness(id: String, brightness: Double, now: Date = Date()) {
+        groupedLights[id, default: PendingLightUpdate()].brightness = Self.pending(brightness, now: now)
+    }
+
+    mutating func recordGroupedLightColorTemperature(id: String, mirek: Int, now: Date = Date()) {
+        groupedLights[id, default: PendingLightUpdate()].colorTemperature = Self.pending(mirek, now: now)
+    }
+
+    mutating func recordLightOn(id: String, on: Bool, now: Date = Date()) {
+        lights[id, default: PendingLightUpdate()].on = Self.pending(on, now: now)
+    }
+
+    mutating func recordLightBrightness(id: String, brightness: Double, now: Date = Date()) {
+        lights[id, default: PendingLightUpdate()].brightness = Self.pending(brightness, now: now)
+    }
+
+    mutating func recordLightColor(id: String, xy: CIEXYColor, now: Date = Date()) {
+        lights[id, default: PendingLightUpdate()].color = Self.pending(xy, now: now)
+    }
+
+    mutating func recordLightColorTemperature(id: String, mirek: Int, now: Date = Date()) {
+        lights[id, default: PendingLightUpdate()].colorTemperature = Self.pending(mirek, now: now)
+    }
+
+    mutating func clearGroupedLightOn(id: String) {
+        Self.clear(id: id, in: &groupedLights) { $0.on = nil }
+    }
+
+    mutating func clearGroupedLightBrightness(id: String) {
+        Self.clear(id: id, in: &groupedLights) { $0.brightness = nil }
+    }
+
+    mutating func clearGroupedLightColorTemperature(id: String) {
+        Self.clear(id: id, in: &groupedLights) { $0.colorTemperature = nil }
+    }
+
+    mutating func clearLightOn(id: String) {
+        Self.clear(id: id, in: &lights) { $0.on = nil }
+    }
+
+    mutating func clearLightBrightness(id: String) {
+        Self.clear(id: id, in: &lights) { $0.brightness = nil }
+    }
+
+    mutating func clearLightColor(id: String) {
+        Self.clear(id: id, in: &lights) { $0.color = nil }
+    }
+
+    mutating func clearLightColorTemperature(id: String) {
+        Self.clear(id: id, in: &lights) { $0.colorTemperature = nil }
+    }
+
+    mutating func filter(_ event: HueEventResource, kind: ResourceKind, now: Date = Date()) -> HueEventResource {
+        switch kind {
+        case .groupedLight:
+            return Self.filter(event, pendingUpdates: &groupedLights, now: now)
+        case .light:
+            return Self.filter(event, pendingUpdates: &lights, now: now)
+        }
+    }
+
+    private static func pending<Value: Sendable>(_ value: Value, now: Date) -> PendingValue<Value> {
+        PendingValue(value: value, expiresAt: now.addingTimeInterval(Self.protectionWindow))
+    }
+
+    private static func filter(
+        _ event: HueEventResource,
+        pendingUpdates: inout [String: PendingLightUpdate],
+        now: Date
+    ) -> HueEventResource {
+        guard var pending = pendingUpdates[event.id] else { return event }
+
+        var on = event.on
+        var dimming = event.dimming
+        var color = event.color
+        var colorTemperature = event.colorTemperature
+
+        Self.filter(&on, pending: &pending.on, now: now) { eventValue, pendingValue in
+            eventValue.on == pendingValue
+        }
+        Self.filter(&dimming, pending: &pending.brightness, now: now) { eventValue, pendingValue in
+            Self.brightnessMatches(eventValue.brightness, pendingValue)
+        }
+        Self.filter(&color, pending: &pending.color, now: now) { eventValue, pendingValue in
+            Self.colorMatches(eventValue.xy, pendingValue)
+        }
+        Self.filter(&colorTemperature, pending: &pending.colorTemperature, now: now) { eventValue, pendingValue in
+            eventValue.mirek == pendingValue
+        }
+
+        if pending.isEmpty {
+            pendingUpdates[event.id] = nil
+        } else {
+            pendingUpdates[event.id] = pending
+        }
+
+        return HueEventResource(
+            id: event.id,
+            type: event.type,
+            on: on,
+            dimming: dimming,
+            color: color,
+            colorTemperature: colorTemperature,
+            status: event.status,
+            metadata: event.metadata,
+            speed: event.speed
+        )
+    }
+
+    private static func clear(
+        id: String,
+        in pendingUpdates: inout [String: PendingLightUpdate],
+        clearField: (inout PendingLightUpdate) -> Void
+    ) {
+        guard var pending = pendingUpdates[id] else { return }
+        clearField(&pending)
+        if pending.isEmpty {
+            pendingUpdates[id] = nil
+        } else {
+            pendingUpdates[id] = pending
+        }
+    }
+
+    private static func filter<EventValue, Pending>(
+        _ eventValue: inout EventValue?,
+        pending pendingValue: inout PendingValue<Pending>?,
+        now: Date,
+        matches: (EventValue, Pending) -> Bool
+    ) {
+        guard let activePending = pendingValue else { return }
+        guard !activePending.isExpired(at: now) else {
+            pendingValue = nil
+            return
+        }
+        guard let eventValueToCompare = eventValue else { return }
+        if matches(eventValueToCompare, activePending.value) {
+            pendingValue = nil
+        } else {
+            eventValue = nil
+        }
+    }
+
+    private static func brightnessMatches(_ lhs: Double, _ rhs: Double) -> Bool {
+        abs(lhs - rhs) <= 0.5
+    }
+
+    private static func colorMatches(_ lhs: CIEXYColor, _ rhs: CIEXYColor) -> Bool {
+        abs(lhs.x - rhs.x) <= 0.0001 && abs(lhs.y - rhs.y) <= 0.0001
+    }
+}
+
+private struct PendingLightUpdate: Sendable {
+    var on: PendingValue<Bool>?
+    var brightness: PendingValue<Double>?
+    var color: PendingValue<CIEXYColor>?
+    var colorTemperature: PendingValue<Int>?
+
+    var isEmpty: Bool {
+        on == nil && brightness == nil && color == nil && colorTemperature == nil
+    }
+}
+
+private struct PendingValue<Value: Sendable>: Sendable {
+    let value: Value
+    let expiresAt: Date
+
+    func isExpired(at now: Date) -> Bool {
+        now >= expiresAt
+    }
+}

--- a/Sources/HueBar/Views/BrightnessSliderInteraction.swift
+++ b/Sources/HueBar/Views/BrightnessSliderInteraction.swift
@@ -1,0 +1,28 @@
+enum BrightnessSliderAction: Equatable {
+    case none
+    case updateSlider(Double)
+    case commit(Double)
+}
+
+struct BrightnessSliderInteraction {
+    private(set) var isEditing = false
+
+    mutating func editingChanged(_ editing: Bool, currentBrightness: Double) -> BrightnessSliderAction {
+        isEditing = editing
+        return editing ? .none : .commit(currentBrightness)
+    }
+
+    func bridgeBrightnessChanged(_ brightness: Double) -> BrightnessSliderAction {
+        guard !isEditing else { return .none }
+        return .updateSlider(Self.sliderValue(for: brightness))
+    }
+
+    func sliderBrightnessChanged(_ brightness: Double) -> BrightnessSliderAction {
+        guard isEditing else { return .none }
+        return .commit(brightness)
+    }
+
+    static func sliderValue(for brightness: Double) -> Double {
+        max(brightness, 1)
+    }
+}

--- a/Sources/HueBar/Views/LightCard.swift
+++ b/Sources/HueBar/Views/LightCard.swift
@@ -68,6 +68,7 @@ struct LightCard: View {
         Binding(
             get: { light.isOn },
             set: { newValue in
+                apiClient.previewLightOn(id: light.id, on: newValue)
                 Task { try? await apiClient.toggleLight(id: light.id, on: newValue) }
             }
         )

--- a/Sources/HueBar/Views/LightCard.swift
+++ b/Sources/HueBar/Views/LightCard.swift
@@ -68,7 +68,6 @@ struct LightCard: View {
         Binding(
             get: { light.isOn },
             set: { newValue in
-                apiClient.previewLightOn(id: light.id, on: newValue)
                 Task { try? await apiClient.toggleLight(id: light.id, on: newValue) }
             }
         )

--- a/Sources/HueBar/Views/LightDetailView.swift
+++ b/Sources/HueBar/Views/LightDetailView.swift
@@ -32,6 +32,7 @@ struct LightDetailView: View {
             // Color wheel for full-color lights
             if light.supportsColor {
                 ColorWheelView(xy: $colorXY) { newXY in
+                    apiClient.previewLightColor(id: light.id, xy: newXY)
                     debounce(task: &colorDebounce) {
                         try? await apiClient.setLightColor(id: light.id, xy: newXY)
                     }
@@ -42,6 +43,7 @@ struct LightDetailView: View {
             // Color temperature slider for temp-only lights (not shown if full color is available)
             if !light.supportsColor && light.supportsColorTemperature {
                 ColorTemperatureSlider(mirek: $colorTempMirek) { newMirek in
+                    apiClient.previewLightColorTemperature(id: light.id, mirek: newMirek)
                     debounce(task: &tempDebounce) {
                         try? await apiClient.setLightColorTemperature(id: light.id, mirek: newMirek)
                     }
@@ -66,6 +68,7 @@ struct LightDetailView: View {
         .onAppear { syncFromLight() }
         .onChange(of: light.id) { _, _ in syncFromLight() }
         .onChange(of: sliderBrightness) { _, newValue in
+            apiClient.previewLightBrightness(id: light.id, brightness: newValue)
             debounce(task: &brightnessDebounce) {
                 try? await apiClient.setLightBrightness(id: light.id, brightness: newValue)
             }

--- a/Sources/HueBar/Views/LightDetailView.swift
+++ b/Sources/HueBar/Views/LightDetailView.swift
@@ -11,6 +11,7 @@ struct LightDetailView: View {
     @State private var brightnessDebounce: Task<Void, Never>?
     @State private var colorDebounce: Task<Void, Never>?
     @State private var tempDebounce: Task<Void, Never>?
+    @State private var brightnessInteraction = BrightnessSliderInteraction()
 
     var body: some View {
         VStack(spacing: 12) {
@@ -56,9 +57,15 @@ struct LightDetailView: View {
                     Image(systemName: "sun.min")
                         .font(.caption)
                         .foregroundStyle(.secondary)
-                    Slider(value: $sliderBrightness, in: 1...100)
+                    Slider(value: $sliderBrightness, in: 1...100) { editing in
+                        handleBrightnessAction(
+                            brightnessInteraction.editingChanged(editing, currentBrightness: sliderBrightness)
+                        )
+                    }
                         .controlSize(.small)
                         .tint(.hueAccent)
+                        .accessibilityLabel("\(light.name) brightness")
+                        .accessibilityValue("\(Int(sliderBrightness))%")
                     Image(systemName: "sun.max.fill")
                         .font(.caption)
                         .foregroundStyle(.secondary)
@@ -67,11 +74,11 @@ struct LightDetailView: View {
         }
         .onAppear { syncFromLight() }
         .onChange(of: light.id) { _, _ in syncFromLight() }
+        .onChange(of: light.brightness) { _, newValue in
+            handleBrightnessAction(brightnessInteraction.bridgeBrightnessChanged(newValue))
+        }
         .onChange(of: sliderBrightness) { _, newValue in
-            apiClient.previewLightBrightness(id: light.id, brightness: newValue)
-            debounce(task: &brightnessDebounce) {
-                try? await apiClient.setLightBrightness(id: light.id, brightness: newValue)
-            }
+            handleBrightnessAction(brightnessInteraction.sliderBrightnessChanged(newValue))
         }
         .onDisappear {
             brightnessDebounce?.cancel()
@@ -81,12 +88,30 @@ struct LightDetailView: View {
     }
 
     private func syncFromLight() {
-        sliderBrightness = max(light.brightness, 1)
+        sliderBrightness = BrightnessSliderInteraction.sliderValue(for: light.brightness)
         if let xy = light.color?.xy {
             colorXY = xy
         }
         if let mirek = light.colorTemperature?.mirek {
             colorTempMirek = mirek
+        }
+    }
+
+    private func handleBrightnessAction(_ action: BrightnessSliderAction) {
+        switch action {
+        case .none:
+            break
+        case .updateSlider(let brightness):
+            sliderBrightness = brightness
+        case .commit(let brightness):
+            commitBrightnessChange(brightness)
+        }
+    }
+
+    private func commitBrightnessChange(_ brightness: Double) {
+        apiClient.previewLightBrightness(id: light.id, brightness: brightness)
+        debounce(task: &brightnessDebounce) {
+            try? await apiClient.setLightBrightness(id: light.id, brightness: brightness)
         }
     }
 }

--- a/Sources/HueBar/Views/LightRowView.swift
+++ b/Sources/HueBar/Views/LightRowView.swift
@@ -67,6 +67,9 @@ struct LightRowView: View {
                     .foregroundStyle(isOn ? .white.opacity(0.6) : .white.opacity(0.2))
                 Slider(value: $sliderBrightness, in: 1...100) { editing in
                     isUserDragging = editing
+                    if !editing {
+                        commitBrightnessChange(sliderBrightness)
+                    }
                 }
                     .controlSize(.small)
                     .tint(isOn ? .white.opacity(0.8) : .white.opacity(0.15))
@@ -94,10 +97,8 @@ struct LightRowView: View {
             }
         }
         .onChange(of: sliderBrightness) { _, newValue in
-            guard isUserDragging, let id = groupedLightId else { return }
-            debounce(task: &debounceTask) {
-                try? await apiClient.setBrightness(groupedLightId: id, brightness: newValue)
-            }
+            guard isUserDragging else { return }
+            commitBrightnessChange(newValue)
         }
         .onDisappear { debounceTask?.cancel() }
     }
@@ -125,8 +126,17 @@ struct LightRowView: View {
             get: { isOn },
             set: { newValue in
                 guard let id = groupedLightId else { return }
+                apiClient.previewGroupedLightOn(id: id, on: newValue)
                 Task { try? await apiClient.toggleGroupedLight(id: id, on: newValue) }
             }
         )
+    }
+
+    private func commitBrightnessChange(_ brightness: Double) {
+        guard let id = groupedLightId else { return }
+        apiClient.previewBrightness(groupedLightId: id, brightness: brightness)
+        debounce(task: &debounceTask) {
+            try? await apiClient.setBrightness(groupedLightId: id, brightness: brightness)
+        }
     }
 }

--- a/Sources/HueBar/Views/LightRowView.swift
+++ b/Sources/HueBar/Views/LightRowView.swift
@@ -126,7 +126,6 @@ struct LightRowView: View {
             get: { isOn },
             set: { newValue in
                 guard let id = groupedLightId else { return }
-                apiClient.previewGroupedLightOn(id: id, on: newValue)
                 Task { try? await apiClient.toggleGroupedLight(id: id, on: newValue) }
             }
         )

--- a/Sources/HueBar/Views/RoomDetailView.swift
+++ b/Sources/HueBar/Views/RoomDetailView.swift
@@ -268,7 +268,6 @@ struct RoomDetailView: View {
             get: { isOn },
             set: { newValue in
                 guard let id = groupedLightId else { return }
-                apiClient.previewGroupedLightOn(id: id, on: newValue)
                 Task { try? await apiClient.toggleGroupedLight(id: id, on: newValue) }
             }
         )

--- a/Sources/HueBar/Views/RoomDetailView.swift
+++ b/Sources/HueBar/Views/RoomDetailView.swift
@@ -105,6 +105,9 @@ struct RoomDetailView: View {
                             .foregroundStyle(.secondary)
                         Slider(value: $sliderBrightness, in: 1...100) { editing in
                             isUserDraggingBrightness = editing
+                            if !editing {
+                                commitBrightnessChange(sliderBrightness)
+                            }
                         }
                             .controlSize(.small)
                             .tint(.hueAccent)
@@ -124,6 +127,7 @@ struct RoomDetailView: View {
                                 .frame(width: 12)
                             ColorTemperatureSlider(mirek: $sliderMirek) { newMirek in
                                 guard let id = groupedLightId else { return }
+                                apiClient.previewGroupedLightColorTemperature(id: id, mirek: newMirek)
                                 debounce(task: &colorTempDebounceTask) {
                                     try? await apiClient.setGroupedLightColorTemperature(id: id, mirek: newMirek)
                                 }
@@ -242,10 +246,8 @@ struct RoomDetailView: View {
             }
         }
         .onChange(of: sliderBrightness) { _, newValue in
-            guard isUserDraggingBrightness, let id = groupedLightId else { return }
-            debounce(task: &debounceTask) {
-                try? await apiClient.setBrightness(groupedLightId: id, brightness: newValue)
-            }
+            guard isUserDraggingBrightness else { return }
+            commitBrightnessChange(newValue)
         }
         .onChange(of: sliderSpeed) { _, newValue in
             guard isUserDraggingSpeed, let sceneId = activeSceneForGroup?.id else { return }
@@ -266,8 +268,17 @@ struct RoomDetailView: View {
             get: { isOn },
             set: { newValue in
                 guard let id = groupedLightId else { return }
+                apiClient.previewGroupedLightOn(id: id, on: newValue)
                 Task { try? await apiClient.toggleGroupedLight(id: id, on: newValue) }
             }
         )
+    }
+
+    private func commitBrightnessChange(_ brightness: Double) {
+        guard let id = groupedLightId else { return }
+        apiClient.previewBrightness(groupedLightId: id, brightness: brightness)
+        debounce(task: &debounceTask) {
+            try? await apiClient.setBrightness(groupedLightId: id, brightness: brightness)
+        }
     }
 }

--- a/Tests/HueBarTests/HueAPIClientTests.swift
+++ b/Tests/HueBarTests/HueAPIClientTests.swift
@@ -26,6 +26,27 @@ private final class MockURLProtocol: URLProtocol, @unchecked Sendable {
     override func stopLoading() {}
 }
 
+private final class LockedValue<Value>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value: Value
+
+    init(_ value: Value) {
+        self.value = value
+    }
+
+    func set(_ newValue: Value) {
+        lock.lock()
+        value = newValue
+        lock.unlock()
+    }
+
+    func get() -> Value {
+        lock.lock()
+        defer { lock.unlock() }
+        return value
+    }
+}
+
 @MainActor
 private func makeClient() -> HueAPIClient {
     let config = URLSessionConfiguration.ephemeral
@@ -135,6 +156,7 @@ struct HueAPIClientTests {
         client.groupedLights = [
             GroupedLight(id: validId, on: OnState(on: true), dimming: DimmingState(brightness: 80.0), colorTemperature: nil),
         ]
+        let observedStateBeforeResponse = LockedValue<Bool?>(nil)
 
         MockURLProtocol.requestHandler = { request in
             #expect(request.httpMethod == "PUT")
@@ -152,11 +174,18 @@ struct HueAPIClientTests {
                let onDict = body["on"] as? [String: Bool] {
                 #expect(onDict["on"] == false)
             }
+            let stateWasRead = DispatchSemaphore(value: 0)
+            Task { @MainActor in
+                observedStateBeforeResponse.set(client.groupedLights.first?.isOn)
+                stateWasRead.signal()
+            }
+            #expect(stateWasRead.wait(timeout: .now() + 2) == .success)
             let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
             return (response, Data())
         }
 
         try await client.toggleGroupedLight(id: validId, on: false)
+        #expect(observedStateBeforeResponse.get() == false)
         #expect(client.groupedLights.first?.isOn == false)
     }
 
@@ -397,15 +426,23 @@ struct HueAPIClientTests {
         let client = makeClient()
         let validId = "00000000-0000-0000-0000-000000000001"
         client.lights = [makeLight(id: validId, name: "Lamp", ownerRid: "device-A")]
+        let observedStateBeforeResponse = LockedValue<Bool?>(nil)
 
         MockURLProtocol.requestHandler = { request in
             #expect(request.httpMethod == "PUT")
             #expect(request.url?.absoluteString.contains("/clip/v2/resource/light/\(validId)") == true)
+            let stateWasRead = DispatchSemaphore(value: 0)
+            Task { @MainActor in
+                observedStateBeforeResponse.set(client.lights.first?.isOn)
+                stateWasRead.signal()
+            }
+            #expect(stateWasRead.wait(timeout: .now() + 2) == .success)
             let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
             return (response, Data())
         }
 
         try await client.toggleLight(id: validId, on: false)
+        #expect(observedStateBeforeResponse.get() == false)
         #expect(client.lights.first?.isOn == false)
     }
 

--- a/Tests/HueBarTests/HueAPIClientTests.swift
+++ b/Tests/HueBarTests/HueAPIClientTests.swift
@@ -238,6 +238,106 @@ struct HueAPIClientTests {
         }
     }
 
+    @Test func pendingGroupedBrightnessIgnoresStaleSSEUntilMatchingEvent() async throws {
+        // Arrange
+        let client = makeClient()
+        let validId = "00000000-0000-0000-0000-000000000012"
+        client.groupedLights = [
+            GroupedLight(id: validId, on: OnState(on: true), dimming: DimmingState(brightness: 12.0), colorTemperature: nil),
+        ]
+        MockURLProtocol.requestHandler = { request in
+            #expect(request.httpMethod == "PUT")
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (response, Data())
+        }
+
+        // Act
+        try await client.setBrightness(groupedLightId: validId, brightness: 40.0)
+        client.applyEventsForTesting([
+            makeUpdateEvent(
+                resource: HueEventResource(
+                    id: validId,
+                    type: "grouped_light",
+                    on: nil,
+                    dimming: DimmingState(brightness: 12.0),
+                    color: nil,
+                    colorTemperature: nil,
+                    status: nil,
+                    metadata: nil,
+                    speed: nil
+                )
+            ),
+        ])
+
+        // Assert
+        #expect(client.groupedLights.first?.brightness == 40.0)
+
+        // Act
+        client.applyEventsForTesting([
+            makeUpdateEvent(
+                resource: HueEventResource(
+                    id: validId,
+                    type: "grouped_light",
+                    on: nil,
+                    dimming: DimmingState(brightness: 40.0),
+                    color: nil,
+                    colorTemperature: nil,
+                    status: nil,
+                    metadata: nil,
+                    speed: nil
+                )
+            ),
+        ])
+        client.applyEventsForTesting([
+            makeUpdateEvent(
+                resource: HueEventResource(
+                    id: validId,
+                    type: "grouped_light",
+                    on: nil,
+                    dimming: DimmingState(brightness: 65.0),
+                    color: nil,
+                    colorTemperature: nil,
+                    status: nil,
+                    metadata: nil,
+                    speed: nil
+                )
+            ),
+        ])
+
+        // Assert
+        #expect(client.groupedLights.first?.brightness == 65.0)
+    }
+
+    @Test func previewGroupedBrightnessProtectsDebouncedChangeFromStaleSSE() {
+        // Arrange
+        let client = makeClient()
+        let validId = "00000000-0000-0000-0000-000000000013"
+        client.groupedLights = [
+            GroupedLight(id: validId, on: OnState(on: true), dimming: DimmingState(brightness: 12.0), colorTemperature: nil),
+        ]
+
+        // Act
+        client.previewBrightness(groupedLightId: validId, brightness: 40.0)
+        client.applyEventsForTesting([
+            makeUpdateEvent(
+                resource: HueEventResource(
+                    id: validId,
+                    type: "grouped_light",
+                    on: nil,
+                    dimming: DimmingState(brightness: 12.0),
+                    color: nil,
+                    colorTemperature: nil,
+                    status: nil,
+                    metadata: nil,
+                    speed: nil
+                )
+            ),
+        ])
+
+        // Assert
+        #expect(client.groupedLights.first?.brightness == 40.0)
+    }
+
     @Test func lightsFilteredByRoom() {
         let client = makeClient()
         let room = Room(
@@ -545,6 +645,15 @@ struct HueAPIClientTests {
             dimming: DimmingState(brightness: 50),
             color: nil,
             colorTemperature: nil
+        )
+    }
+
+    private func makeUpdateEvent(resource: HueEventResource) -> HueEvent {
+        HueEvent(
+            creationtime: "2024-01-01T00:00:00Z",
+            id: UUID().uuidString,
+            type: .update,
+            data: [resource]
         )
     }
 }

--- a/Tests/HueBarTests/LightControlsRegressionTests.swift
+++ b/Tests/HueBarTests/LightControlsRegressionTests.swift
@@ -1,0 +1,34 @@
+import Testing
+@testable import HueBar
+
+@Suite("Light controls regressions")
+struct LightControlsRegressionTests {
+    @Test func bridgeBrightnessSyncsSliderWhenIdle() {
+        let interaction = BrightnessSliderInteraction()
+
+        #expect(interaction.bridgeBrightnessChanged(42) == .updateSlider(42))
+        #expect(interaction.bridgeBrightnessChanged(0) == .updateSlider(1))
+    }
+
+    @Test func bridgeBrightnessDoesNotOverwriteSliderWhileDragging() {
+        var interaction = BrightnessSliderInteraction()
+
+        #expect(interaction.editingChanged(true, currentBrightness: 50) == .none)
+        #expect(interaction.bridgeBrightnessChanged(12) == .none)
+    }
+
+    @Test func sliderChangesOnlyCommitWhileDragging() {
+        var interaction = BrightnessSliderInteraction()
+
+        #expect(interaction.sliderBrightnessChanged(55) == .none)
+        #expect(interaction.editingChanged(true, currentBrightness: 55) == .none)
+        #expect(interaction.sliderBrightnessChanged(60) == .commit(60))
+    }
+
+    @Test func endingDragCommitsCurrentSliderValue() {
+        var interaction = BrightnessSliderInteraction()
+
+        #expect(interaction.editingChanged(true, currentBrightness: 40) == .none)
+        #expect(interaction.editingChanged(false, currentBrightness: 64) == .commit(64))
+    }
+}

--- a/Tests/HueBarTests/OptimisticUpdateTrackerTests.swift
+++ b/Tests/HueBarTests/OptimisticUpdateTrackerTests.swift
@@ -13,7 +13,7 @@ struct OptimisticUpdateTrackerTests {
         var groupedLights = [
             GroupedLight(id: "gl-1", on: OnState(on: true), dimming: DimmingState(brightness: 40.0), colorTemperature: nil),
         ]
-        tracker.recordGroupedLightBrightness(id: "gl-1", brightness: 40.0, now: now)
+        tracker.record(.brightness(40.0), for: .groupedLight, id: "gl-1", now: now)
         let staleEvent = HueEventResource(
             id: "gl-1",
             type: "grouped_light",
@@ -41,7 +41,7 @@ struct OptimisticUpdateTrackerTests {
         var groupedLights = [
             GroupedLight(id: "gl-1", on: OnState(on: true), dimming: DimmingState(brightness: 40.0), colorTemperature: nil),
         ]
-        tracker.recordGroupedLightBrightness(id: "gl-1", brightness: 40.0, now: now)
+        tracker.record(.brightness(40.0), for: .groupedLight, id: "gl-1", now: now)
         let matchingEvent = HueEventResource(
             id: "gl-1",
             type: "grouped_light",
@@ -80,7 +80,7 @@ struct OptimisticUpdateTrackerTests {
         var groupedLights = [
             GroupedLight(id: "gl-1", on: OnState(on: true), dimming: DimmingState(brightness: 40.0), colorTemperature: nil),
         ]
-        tracker.recordGroupedLightBrightness(id: "gl-1", brightness: 40.0, now: now)
+        tracker.record(.brightness(40.0), for: .groupedLight, id: "gl-1", now: now)
         let roundedEvent = HueEventResource(
             id: "gl-1",
             type: "grouped_light",
@@ -119,8 +119,8 @@ struct OptimisticUpdateTrackerTests {
         var groupedLights = [
             GroupedLight(id: "gl-1", on: OnState(on: true), dimming: DimmingState(brightness: 70.0), colorTemperature: nil),
         ]
-        tracker.recordGroupedLightBrightness(id: "gl-1", brightness: 50.0, now: now)
-        tracker.recordGroupedLightBrightness(id: "gl-1", brightness: 70.0, now: now)
+        tracker.record(.brightness(50.0), for: .groupedLight, id: "gl-1", now: now)
+        tracker.record(.brightness(70.0), for: .groupedLight, id: "gl-1", now: now)
         let olderEvent = HueEventResource(
             id: "gl-1",
             type: "grouped_light",
@@ -159,7 +159,7 @@ struct OptimisticUpdateTrackerTests {
         var groupedLights = [
             GroupedLight(id: "gl-1", on: OnState(on: true), dimming: DimmingState(brightness: 40.0), colorTemperature: nil),
         ]
-        tracker.recordGroupedLightBrightness(id: "gl-1", brightness: 40.0, now: now)
+        tracker.record(.brightness(40.0), for: .groupedLight, id: "gl-1", now: now)
         let staleEvent = HueEventResource(
             id: "gl-1",
             type: "grouped_light",
@@ -199,7 +199,7 @@ struct OptimisticUpdateTrackerTests {
                 colorTemperature: nil
             ),
         ]
-        tracker.recordLightOn(id: "light-1", on: false, now: now)
+        tracker.record(.on(false), for: .light, id: "light-1", now: now)
         let staleEvent = HueEventResource(
             id: "light-1",
             type: "light",

--- a/Tests/HueBarTests/OptimisticUpdateTrackerTests.swift
+++ b/Tests/HueBarTests/OptimisticUpdateTrackerTests.swift
@@ -1,0 +1,143 @@
+import Foundation
+import Testing
+@testable import HueBar
+
+@Suite("OptimisticUpdateTracker")
+struct OptimisticUpdateTrackerTests {
+    private let now = Date(timeIntervalSince1970: 0)
+
+    @Test("Stale grouped light brightness events do not overwrite a pending local change")
+    func staleGroupedLightBrightnessIgnored() throws {
+        // Arrange
+        var tracker = OptimisticUpdateTracker()
+        var groupedLights = [
+            GroupedLight(id: "gl-1", on: OnState(on: true), dimming: DimmingState(brightness: 40.0), colorTemperature: nil),
+        ]
+        tracker.recordGroupedLightBrightness(id: "gl-1", brightness: 40.0, now: now)
+        let staleEvent = HueEventResource(
+            id: "gl-1",
+            type: "grouped_light",
+            on: nil,
+            dimming: DimmingState(brightness: 12.0),
+            color: nil,
+            colorTemperature: nil,
+            status: nil,
+            metadata: nil,
+            speed: nil
+        )
+
+        // Act
+        let filteredEvent = tracker.filter(staleEvent, kind: .groupedLight, now: now)
+        EventStreamUpdater.apply(filteredEvent, to: &groupedLights)
+
+        // Assert
+        #expect(groupedLights[0].brightness == 40.0)
+    }
+
+    @Test("Matching grouped light brightness event confirms the pending local change")
+    func matchingGroupedLightBrightnessClearsPendingChange() throws {
+        // Arrange
+        var tracker = OptimisticUpdateTracker()
+        var groupedLights = [
+            GroupedLight(id: "gl-1", on: OnState(on: true), dimming: DimmingState(brightness: 40.0), colorTemperature: nil),
+        ]
+        tracker.recordGroupedLightBrightness(id: "gl-1", brightness: 40.0, now: now)
+        let matchingEvent = HueEventResource(
+            id: "gl-1",
+            type: "grouped_light",
+            on: nil,
+            dimming: DimmingState(brightness: 40.0),
+            color: nil,
+            colorTemperature: nil,
+            status: nil,
+            metadata: nil,
+            speed: nil
+        )
+        let laterEvent = HueEventResource(
+            id: "gl-1",
+            type: "grouped_light",
+            on: nil,
+            dimming: DimmingState(brightness: 65.0),
+            color: nil,
+            colorTemperature: nil,
+            status: nil,
+            metadata: nil,
+            speed: nil
+        )
+
+        // Act
+        EventStreamUpdater.apply(tracker.filter(matchingEvent, kind: .groupedLight, now: now), to: &groupedLights)
+        EventStreamUpdater.apply(tracker.filter(laterEvent, kind: .groupedLight, now: now), to: &groupedLights)
+
+        // Assert
+        #expect(groupedLights[0].brightness == 65.0)
+    }
+
+    @Test("Expired grouped light brightness protection allows bridge state to apply")
+    func expiredGroupedLightBrightnessProtectionAllowsEvent() throws {
+        // Arrange
+        var tracker = OptimisticUpdateTracker()
+        var groupedLights = [
+            GroupedLight(id: "gl-1", on: OnState(on: true), dimming: DimmingState(brightness: 40.0), colorTemperature: nil),
+        ]
+        tracker.recordGroupedLightBrightness(id: "gl-1", brightness: 40.0, now: now)
+        let staleEvent = HueEventResource(
+            id: "gl-1",
+            type: "grouped_light",
+            on: nil,
+            dimming: DimmingState(brightness: 12.0),
+            color: nil,
+            colorTemperature: nil,
+            status: nil,
+            metadata: nil,
+            speed: nil
+        )
+
+        // Act
+        let filteredEvent = tracker.filter(
+            staleEvent,
+            kind: .groupedLight,
+            now: now.addingTimeInterval(OptimisticUpdateTracker.protectionWindow + 0.1)
+        )
+        EventStreamUpdater.apply(filteredEvent, to: &groupedLights)
+
+        // Assert
+        #expect(groupedLights[0].brightness == 12.0)
+    }
+
+    @Test("Stale light toggle events do not overwrite a pending local change")
+    func staleLightToggleIgnored() throws {
+        // Arrange
+        var tracker = OptimisticUpdateTracker()
+        var lights = [
+            HueLight(
+                id: "light-1",
+                owner: ResourceLink(rid: "device-1", rtype: "device"),
+                metadata: LightMetadata(name: "Desk Lamp", archetype: "table_wash"),
+                on: OnState(on: false),
+                dimming: DimmingState(brightness: 50.0),
+                color: nil,
+                colorTemperature: nil
+            ),
+        ]
+        tracker.recordLightOn(id: "light-1", on: false, now: now)
+        let staleEvent = HueEventResource(
+            id: "light-1",
+            type: "light",
+            on: OnState(on: true),
+            dimming: nil,
+            color: nil,
+            colorTemperature: nil,
+            status: nil,
+            metadata: nil,
+            speed: nil
+        )
+
+        // Act
+        let filteredEvent = tracker.filter(staleEvent, kind: .light, now: now)
+        EventStreamUpdater.apply(filteredEvent, to: &lights)
+
+        // Assert
+        #expect(lights[0].isOn == false)
+    }
+}

--- a/Tests/HueBarTests/OptimisticUpdateTrackerTests.swift
+++ b/Tests/HueBarTests/OptimisticUpdateTrackerTests.swift
@@ -73,6 +73,85 @@ struct OptimisticUpdateTrackerTests {
         #expect(groupedLights[0].brightness == 65.0)
     }
 
+    @Test("Approximate grouped light brightness match confirms the pending local change")
+    func approximateGroupedLightBrightnessClearsPendingChange() throws {
+        // Arrange
+        var tracker = OptimisticUpdateTracker()
+        var groupedLights = [
+            GroupedLight(id: "gl-1", on: OnState(on: true), dimming: DimmingState(brightness: 40.0), colorTemperature: nil),
+        ]
+        tracker.recordGroupedLightBrightness(id: "gl-1", brightness: 40.0, now: now)
+        let roundedEvent = HueEventResource(
+            id: "gl-1",
+            type: "grouped_light",
+            on: nil,
+            dimming: DimmingState(brightness: 40.39),
+            color: nil,
+            colorTemperature: nil,
+            status: nil,
+            metadata: nil,
+            speed: nil
+        )
+        let laterEvent = HueEventResource(
+            id: "gl-1",
+            type: "grouped_light",
+            on: nil,
+            dimming: DimmingState(brightness: 65.0),
+            color: nil,
+            colorTemperature: nil,
+            status: nil,
+            metadata: nil,
+            speed: nil
+        )
+
+        // Act
+        EventStreamUpdater.apply(tracker.filter(roundedEvent, kind: .groupedLight, now: now), to: &groupedLights)
+        EventStreamUpdater.apply(tracker.filter(laterEvent, kind: .groupedLight, now: now), to: &groupedLights)
+
+        // Assert
+        #expect(groupedLights[0].brightness == 65.0)
+    }
+
+    @Test("Older grouped light brightness confirmation does not overwrite a newer pending value")
+    func olderGroupedLightBrightnessConfirmationIgnored() throws {
+        // Arrange
+        var tracker = OptimisticUpdateTracker()
+        var groupedLights = [
+            GroupedLight(id: "gl-1", on: OnState(on: true), dimming: DimmingState(brightness: 70.0), colorTemperature: nil),
+        ]
+        tracker.recordGroupedLightBrightness(id: "gl-1", brightness: 50.0, now: now)
+        tracker.recordGroupedLightBrightness(id: "gl-1", brightness: 70.0, now: now)
+        let olderEvent = HueEventResource(
+            id: "gl-1",
+            type: "grouped_light",
+            on: nil,
+            dimming: DimmingState(brightness: 50.0),
+            color: nil,
+            colorTemperature: nil,
+            status: nil,
+            metadata: nil,
+            speed: nil
+        )
+        let newerEvent = HueEventResource(
+            id: "gl-1",
+            type: "grouped_light",
+            on: nil,
+            dimming: DimmingState(brightness: 70.0),
+            color: nil,
+            colorTemperature: nil,
+            status: nil,
+            metadata: nil,
+            speed: nil
+        )
+
+        // Act
+        EventStreamUpdater.apply(tracker.filter(olderEvent, kind: .groupedLight, now: now), to: &groupedLights)
+        EventStreamUpdater.apply(tracker.filter(newerEvent, kind: .groupedLight, now: now), to: &groupedLights)
+
+        // Assert
+        #expect(groupedLights[0].brightness == 70.0)
+    }
+
     @Test("Expired grouped light brightness protection allows bridge state to apply")
     func expiredGroupedLightBrightnessProtectionAllowsEvent() throws {
         // Arrange


### PR DESCRIPTION
This PR fixes a small but noticeable UI jitter when changing Hue state from HueBar while SSE is connected.

The issue was that local slider changes were debounced before sending the PUT request, but stale SSE/model state could still arrive during that debounce window. That meant the UI could briefly show the local value, snap back to the old bridge value, then jump forward again once the bridge eventually emitted the new value.

This PR:

- Adds an `OptimisticUpdateTracker` for pending local changes on grouped lights and individual lights
- Previews local changes immediately when toggles, brightness sliders, color controls, or color temperature controls are changed
- Filters stale SSE fields while a matching local update is pending, without blocking unrelated fields from the same event
- Clears pending state when the bridge confirms the expected value, or after a short timeout so the bridge can become authoritative again
- Updates `EventStreamUpdater` to mutate model fields directly instead of rebuilding whole structs
- Adds regression coverage for stale SSE during optimistic updates, matching confirmation events, timeout behavior, and the debounced preview path

<details>
<summary>Before video</summary>

In the before video, changing the slider from my Mac briefly snaps back to the previous bridge value before SSE catches up with the local change.

https://github.com/user-attachments/assets/37eb3584-2c74-4661-88c0-d2dc1117d20f

</details>

<details>
<summary>After video</summary>

In the after video, the first half shows changing the slider from my Mac, where the local UI stays stable while the debounced bridge request catches up. In the second half I change the same light from my phone, and SSE is still reflected correctly on my Mac.

https://github.com/user-attachments/assets/313adb81-4af4-45c3-a8d0-70c379a0c42e

</details>

P.S: I just noticed that both videos are using different sliders, I tested on all sliders and I can confirm it behaves the same way regardless.