### PR TITLE
fix(bridge): retry transient connection failures

### DIFF
--- a/Sources/HueBar/Services/BridgeConnection.swift
+++ b/Sources/HueBar/Services/BridgeConnection.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Observation
 
 enum BridgeConnectionStatus: Sendable, Equatable {
     case disconnected
@@ -14,20 +15,33 @@ final class BridgeConnection: Identifiable {
     var name: String
     let client: HueAPIClient
     var status: BridgeConnectionStatus = .disconnected
+    private let retryDelay: Duration
+    @ObservationIgnored private var reconnectTask: Task<Void, Never>?
 
-    init(credentials: BridgeCredentials) throws {
+    init(credentials: BridgeCredentials, retryDelay: Duration = .seconds(5)) throws {
         self.id = credentials.id
         self.name = credentials.name
+        self.retryDelay = retryDelay
         self.client = try HueAPIClient(bridgeIP: credentials.bridgeIP, applicationKey: credentials.applicationKey)
+    }
+
+    init(id: String, name: String, client: HueAPIClient, retryDelay: Duration = .seconds(5)) {
+        self.id = id
+        self.name = name
+        self.client = client
+        self.retryDelay = retryDelay
     }
 
     /// Connect to the bridge: fetch all data and start event stream
     func connect() async {
         guard status != .connected, status != .connecting else { return }
+        reconnectTask?.cancel()
+        reconnectTask = nil
         status = .connecting
         await client.fetchAll()
         if let error = client.lastError {
             status = .error(error)
+            scheduleReconnect()
         } else {
             status = .connected
             client.startEventStream()
@@ -36,6 +50,25 @@ final class BridgeConnection: Identifiable {
 
     /// Disconnect from the bridge
     func disconnect() {
+        reconnectTask?.cancel()
+        reconnectTask = nil
         client.stopEventStream()
+    }
+
+    private func scheduleReconnect() {
+        reconnectTask?.cancel()
+        reconnectTask = Task { [weak self, retryDelay] in
+            do {
+                try await Task.sleep(for: retryDelay)
+            } catch {
+                return
+            }
+            await self?.retryConnection()
+        }
+    }
+
+    private func retryConnection() async {
+        reconnectTask = nil
+        await connect()
     }
 }

--- a/Sources/HueBar/Views/MenuBarView.swift
+++ b/Sources/HueBar/Views/MenuBarView.swift
@@ -13,7 +13,11 @@ struct MenuBarView: View {
 
     /// The primary bridge client (first connected bridge)
     private var primaryClient: HueAPIClient? {
-        bridgeManager.bridges.first?.client
+        primaryBridge?.client
+    }
+
+    private var primaryBridge: BridgeConnection? {
+        bridgeManager.bridges.first
     }
 
     /// Whether to show multi-bridge section headers
@@ -200,16 +204,17 @@ struct MenuBarView: View {
 
     @ViewBuilder
     private var singleBridgeContent: some View {
-        if let client = primaryClient {
-            if client.isLoading && client.rooms.isEmpty && client.zones.isEmpty {
+        if let bridge = primaryBridge {
+            let client = bridge.client
+            if shouldShowInitialLoading(for: bridge) {
                 Spacer()
                 ProgressView("Loading…")
                 Spacer()
             } else {
                 ScrollView {
                     VStack(alignment: .leading, spacing: 12) {
-                        if let error = client.lastError {
-                            Label(error, systemImage: "exclamationmark.triangle")
+                        if case .error(let message) = bridge.status {
+                            Label(message, systemImage: "exclamationmark.triangle")
                                 .foregroundStyle(.red)
                                 .font(.caption)
                                 .padding(.horizontal)
@@ -286,6 +291,17 @@ struct MenuBarView: View {
             Spacer()
             ProgressView("Loading…")
             Spacer()
+        }
+    }
+
+    private func shouldShowInitialLoading(for bridge: BridgeConnection) -> Bool {
+        let client = bridge.client
+        guard client.rooms.isEmpty && client.zones.isEmpty else { return false }
+        switch bridge.status {
+        case .disconnected, .connecting:
+            return true
+        case .connected, .error:
+            return client.isLoading
         }
     }
 

--- a/Tests/HueBarTests/BridgeManagerTests.swift
+++ b/Tests/HueBarTests/BridgeManagerTests.swift
@@ -74,4 +74,105 @@ extension CredentialStoreTests {
         let ids = Set(manager.bridges.map(\.id))
         #expect(ids == ["stored-1", "stored-2"])
     }
+
+    @Test func bridgeConnectionRetriesAfterTransientNetworkFailure() async throws {
+        // Arrange
+        let context = createRetryTestContext()
+
+        // Act
+        await context.connection.connect()
+
+        // Assert
+        guard case .error = context.connection.status else {
+            Issue.record("Expected first connection attempt to fail")
+            return
+        }
+        #expect(context.client.lastError != nil)
+
+        try await Task.sleep(for: .milliseconds(100))
+
+        #expect(context.connection.status == .connected)
+        #expect(context.client.lastError == nil)
+        #expect(context.requestCount() >= 10)
+
+        context.connection.disconnect()
+    }
+
+    private func createRetryTestContext() -> (
+        connection: BridgeConnection,
+        client: HueAPIClient,
+        requestCount: () -> Int
+    ) {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [BridgeConnectionRetryURLProtocol.self]
+        let session = URLSession(configuration: config)
+        let client = HueAPIClient(bridgeIP: "127.0.0.1:1234", applicationKey: "test-key", session: session)
+
+        let lock = NSLock()
+        var requestCount = 0
+        BridgeConnectionRetryURLProtocol.requestHandler = { request in
+            lock.lock()
+            requestCount += 1
+            let currentRequestCount = requestCount
+            lock.unlock()
+
+            if currentRequestCount <= 5 {
+                throw URLError(.notConnectedToInternet)
+            }
+
+            let path = request.url?.path ?? ""
+            let json: String
+            if path.hasSuffix("/room") {
+                json = #"{"errors":[],"data":[{"id":"room-1","metadata":{"name":"Office","archetype":"office"},"services":[{"rid":"gl-1","rtype":"grouped_light"}],"children":[]}]}"#
+            } else if path.hasSuffix("/grouped_light") {
+                json = #"{"errors":[],"data":[{"id":"gl-1","on":{"on":true},"dimming":{"brightness":75.0}}]}"#
+            } else {
+                json = #"{"errors":[],"data":[]}"#
+            }
+
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (response, Data(json.utf8))
+        }
+
+        let connection = BridgeConnection(
+            id: "office-bridge",
+            name: "Office Bridge",
+            client: client,
+            retryDelay: .milliseconds(10)
+        )
+
+        return (
+            connection: connection,
+            client: client,
+            requestCount: {
+                lock.lock()
+                defer { lock.unlock() }
+                return requestCount
+            }
+        )
+    }
+}
+
+private final class BridgeConnectionRetryURLProtocol: URLProtocol, @unchecked Sendable {
+    nonisolated(unsafe) static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard let handler = Self.requestHandler else {
+            client?.urlProtocolDidFinishLoading(self)
+            return
+        }
+        do {
+            let (response, data) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
 }


### PR DESCRIPTION
The issue here is that a transient startup fetch failure can leave HueBar stuck in the error state. In my case I saw "The Internet connection appears to be offline." in the menu, and restarting the app recovered it, had this happen multiple times while testing other features.

This PR:
- schedules a reconnect after `BridgeConnection.connect()` fails, with the normal app delay set to 5 seconds
- cancels pending reconnects when the bridge disconnects or a new connect attempt starts
- shows the bridge connection error from `BridgeConnection.status`, so stale `HueAPIClient.lastError` does not keep the menu in an error state after a retry succeeds
- adds a regression test that fails the first requests with `URLError(.notConnectedToInternet)` and verifies the bridge eventually reaches `.connect

I tested with this fix and it consistently works on startup.

<details>
<summary>Screenshot</summary>
<img width="292" height="541" alt="Screenshot 2026-05-12 at 9 57 20 AM" src="https://github.com/user-attachments/assets/a5124b71-00b9-4f44-9564-565ad56452a2" />
ed`
</details>
