### PR TITLE
fix(sse): resync bridge state after stream gaps

### DIFF
--- a/Sources/HueBar/Services/EventStreamConnection.swift
+++ b/Sources/HueBar/Services/EventStreamConnection.swift
@@ -1,5 +1,13 @@
 import Foundation
+import os
 import Synchronization
+
+private let logger = Logger(subsystem: "com.huebar", category: "EventStreamConnection")
+
+enum EventStreamMessage: Sendable {
+    case reconnected
+    case events([HueEvent])
+}
 
 /// Owns the SSE event stream lifecycle: connecting, parsing, reconnecting with backoff,
 /// and yielding parsed HueEvent arrays via AsyncStream.
@@ -7,19 +15,30 @@ final class EventStreamConnection: Sendable {
     private let bridgeIP: String
     private let applicationKey: String
     private let session: URLSession
+    private let parsedHost: String
+    private let parsedPort: Int?
+
+    private var isLocalMock: Bool {
+        parsedHost == "127.0.0.1" || parsedHost == "localhost"
+    }
+
+    private var scheme: String { isLocalMock ? "http" : "https" }
 
     private struct State {
         var task: Task<Void, Never>?
-        var continuation: AsyncStream<[HueEvent]>.Continuation?
-        var stream: AsyncStream<[HueEvent]>?
+        var continuation: AsyncStream<EventStreamMessage>.Continuation?
+        var stream: AsyncStream<EventStreamMessage>?
     }
 
     private let state = Mutex(State())
 
     init(bridgeIP: String, applicationKey: String, session: URLSession) {
+        let parsed = IPValidation.parseHostPort(bridgeIP)
         self.bridgeIP = bridgeIP
         self.applicationKey = applicationKey
         self.session = session
+        self.parsedHost = parsed.host
+        self.parsedPort = parsed.port
     }
 
     deinit {
@@ -31,31 +50,36 @@ final class EventStreamConnection: Sendable {
 
     /// Start listening for SSE events. Returns an AsyncStream of parsed event batches.
     /// Idempotent — multiple calls return the same stream.
-    func start() -> AsyncStream<[HueEvent]> {
+    func start() -> AsyncStream<EventStreamMessage> {
         state.withLock { state in
             if let existing = state.stream {
                 return existing
             }
 
-            let (stream, continuation) = AsyncStream<[HueEvent]>.makeStream(bufferingPolicy: .bufferingNewest(100))
+            let (stream, continuation) = AsyncStream<EventStreamMessage>.makeStream(bufferingPolicy: .bufferingNewest(100))
             state.stream = stream
             state.continuation = continuation
 
             let bridgeIP = self.bridgeIP
             let applicationKey = self.applicationKey
             let session = self.session
+            let scheme = self.scheme
+            let host = self.parsedHost
+            let port = self.parsedPort
 
             let task = Task {
                 let parser = SSEParser()
                 var backoff: UInt64 = 1
+                var shouldResyncOnConnect = false
 
                 while !Task.isCancelled {
                     parser.reset()
 
                     do {
                         var components = URLComponents()
-                        components.scheme = "https"
-                        components.host = bridgeIP
+                        components.scheme = scheme
+                        components.host = host
+                        components.port = port
                         components.path = "/eventstream/clip/v2"
                         guard let url = components.url else { break }
 
@@ -67,6 +91,10 @@ final class EventStreamConnection: Sendable {
                         guard let httpResponse = response as? HTTPURLResponse,
                               httpResponse.statusCode == 200 else { throw HueAPIError.invalidResponse }
 
+                        if shouldResyncOnConnect {
+                            continuation.yield(.reconnected)
+                            shouldResyncOnConnect = false
+                        }
                         backoff = 1
 
                         var lineBuffer = Data()
@@ -75,15 +103,18 @@ final class EventStreamConnection: Sendable {
                                 let line = String(data: lineBuffer, encoding: .utf8) ?? ""
                                 lineBuffer.removeAll(keepingCapacity: true)
                                 if let events = parser.processLine(line) {
-                                    continuation.yield(events)
+                                    continuation.yield(.events(events))
                                 }
                             } else {
                                 lineBuffer.append(byte)
                             }
                         }
+                        shouldResyncOnConnect = true
                     } catch is CancellationError {
                         break
                     } catch {
+                        logger.error("Event stream connection failed for \(bridgeIP, privacy: .private): \(error.localizedDescription, privacy: .public)")
+                        shouldResyncOnConnect = true
                         do {
                             try await Task.sleep(for: .seconds(backoff))
                         } catch { break }

--- a/Sources/HueBar/Services/HueAPIClient.swift
+++ b/Sources/HueBar/Services/HueAPIClient.swift
@@ -473,10 +473,6 @@ final class HueAPIClient {
         refreshDebounceTask = nil
     }
 
-    func applyEventsForTesting(_ events: [HueEvent]) {
-        applyEvents(events)
-    }
-
     private func handleEventStreamMessage(_ message: EventStreamMessage) async {
         switch message {
         case .reconnected:
@@ -486,7 +482,7 @@ final class HueAPIClient {
         }
     }
 
-    private func applyEvents(_ events: [HueEvent]) {
+    func applyEvents(_ events: [HueEvent]) {
         for event in events {
             switch event.type {
             case .update:

--- a/Sources/HueBar/Services/HueAPIClient.swift
+++ b/Sources/HueBar/Services/HueAPIClient.swift
@@ -457,9 +457,9 @@ final class HueAPIClient {
         eventStreamConnection = connection
 
         let stream = connection.start()
-        eventConsumingTask = Task {
-            for await events in stream {
-                applyEvents(events)
+        eventConsumingTask = Task { [weak self] in
+            for await message in stream {
+                await self?.handleEventStreamMessage(message)
             }
         }
     }
@@ -477,6 +477,15 @@ final class HueAPIClient {
         applyEvents(events)
     }
 
+    private func handleEventStreamMessage(_ message: EventStreamMessage) async {
+        switch message {
+        case .reconnected:
+            await fetchAll()
+        case .events(let events):
+            applyEvents(events)
+        }
+    }
+
     private func applyEvents(_ events: [HueEvent]) {
         for event in events {
             switch event.type {
@@ -489,6 +498,7 @@ final class HueAPIClient {
                     case "light":
                         let filteredResource = optimisticUpdates.filter(resource, kind: .light)
                         EventStreamUpdater.apply(filteredResource, to: &lights)
+                        syncGroupedLightOnState(containingLightId: resource.id)
                     case "scene":
                         if let status = resource.status?.active,
                            let resourceStatus = resource.status {
@@ -517,6 +527,41 @@ final class HueAPIClient {
                 }
             }
         }
+    }
+
+    private func syncGroupedLightOnState(containingLightId lightId: String) {
+        let affectedGroupedLightIds = groupedLightIds(containingLightId: lightId)
+        for groupedLightId in affectedGroupedLightIds {
+            guard let index = groupedLights.firstIndex(where: { $0.id == groupedLightId }) else { continue }
+            let memberLights = lights(inGroupedLight: groupedLightId)
+            guard !memberLights.isEmpty else { continue }
+            groupedLights[index].on = OnState(on: memberLights.contains(where: \.isOn))
+        }
+    }
+
+    private func groupedLightIds(containingLightId lightId: String) -> Set<String> {
+        var groupedLightIds = Set<String>()
+        for room in rooms where lights(forRoom: room).contains(where: { $0.id == lightId }) {
+            if let groupedLightId = room.groupedLightId {
+                groupedLightIds.insert(groupedLightId)
+            }
+        }
+        for zone in zones where lights(forZone: zone).contains(where: { $0.id == lightId }) {
+            if let groupedLightId = zone.groupedLightId {
+                groupedLightIds.insert(groupedLightId)
+            }
+        }
+        return groupedLightIds
+    }
+
+    private func lights(inGroupedLight groupedLightId: String) -> [HueLight] {
+        if let room = rooms.first(where: { $0.groupedLightId == groupedLightId }) {
+            return lights(forRoom: room)
+        }
+        if let zone = zones.first(where: { $0.groupedLightId == groupedLightId }) {
+            return lights(forZone: zone)
+        }
+        return []
     }
 
     // MARK: - Pinning & Ordering (forwarded to RoomOrderManager)

--- a/Tests/HueBarTests/EventStreamConnectionTests.swift
+++ b/Tests/HueBarTests/EventStreamConnectionTests.swift
@@ -205,18 +205,20 @@ struct EventStreamConnectionMockTests {
         // Should get events after the retry (backoff is 1s for first retry)
         let result = await withTimeout(seconds: 5) {
             var it = stream.makeAsyncIterator()
-            return await it.next()
+            while let message = await it.next() {
+                if case .events(let events) = message {
+                    return events
+                }
+            }
+            return []
         }
 
         connection.stop()
 
         #expect(result != nil, "Should receive events after retrying past the failure")
         if let events = result {
-            #expect(events != nil, "Events batch should not be nil")
-            if let events {
-                #expect(events.count == 1)
-                #expect(events[0].id == "ev-1")
-            }
+            #expect(events.count == 1)
+            #expect(events[0].id == "ev-1")
         }
         #expect(MockSSEProtocol.requestCount >= 2, "Should have made at least 2 requests (1 failure + 1 success)")
     }

--- a/Tests/HueBarTests/HueAPIClientTests.swift
+++ b/Tests/HueBarTests/HueAPIClientTests.swift
@@ -150,6 +150,67 @@ struct HueAPIClientTests {
         #expect(client.lastError == nil)
     }
 
+    @Test func eventStreamReconnectRefreshesBridgeState() async throws {
+        // Arrange
+        let context = createEventStreamReconnectContext()
+        await context.client.fetchAll()
+        #expect(context.client.groupedLights.first?.isOn == true)
+
+        // Act
+        context.client.startEventStream()
+        defer { context.client.stopEventStream() }
+        let didRefresh = await waitUntil {
+            context.client.groupedLights.first?.isOn == false
+        }
+
+        // Assert
+        #expect(didRefresh)
+        #expect(context.groupedLightRequestCount() >= 2)
+        #expect(context.eventStreamRequestCount() >= 2)
+    }
+
+    @Test func lightEventUpdatesContainingRoomGroupedLightState() {
+        // Arrange
+        let client = makeClient()
+        let groupedLightId = "grouped-office"
+        let lightId = "office-light-1"
+        client.rooms = [
+            Room(
+                id: "office-room",
+                metadata: GroupMetadata(name: "Office", archetype: "office"),
+                services: [ResourceLink(rid: groupedLightId, rtype: "grouped_light")],
+                children: [ResourceLink(rid: "office-device-1", rtype: "device")]
+            ),
+        ]
+        client.groupedLights = [
+            GroupedLight(id: groupedLightId, on: OnState(on: true), dimming: DimmingState(brightness: 80), colorTemperature: nil),
+        ]
+        client.lights = [
+            makeLight(id: lightId, name: "Office Desk", ownerRid: "office-device-1"),
+        ]
+
+        // Act
+        client.applyEventsForTesting([
+            makeUpdateEvent(resources: [
+                HueEventResource(
+                    id: lightId,
+                    type: "light",
+                    on: OnState(on: false),
+                    dimming: nil,
+                    color: nil,
+                    colorTemperature: nil,
+                    status: nil,
+                    metadata: nil,
+                    speed: nil
+                ),
+            ]),
+        ])
+
+        // Assert
+        #expect(client.lights.first?.isOn == false)
+        #expect(client.groupedLight(for: groupedLightId)?.isOn == false)
+    }
+
     @Test func toggleGroupedLightOptimisticUpdate() async throws {
         let client = makeClient()
         let validId = "00000000-0000-0000-0000-000000000001"
@@ -282,7 +343,7 @@ struct HueAPIClientTests {
 
         // Act
         try await client.setBrightness(groupedLightId: validId, brightness: 40.0)
-        client.applyEventsForTesting([
+        client.applyEvents([
             makeUpdateEvent(
                 resource: HueEventResource(
                     id: validId,
@@ -302,7 +363,7 @@ struct HueAPIClientTests {
         #expect(client.groupedLights.first?.brightness == 40.0)
 
         // Act
-        client.applyEventsForTesting([
+        client.applyEvents([
             makeUpdateEvent(
                 resource: HueEventResource(
                     id: validId,
@@ -317,7 +378,7 @@ struct HueAPIClientTests {
                 )
             ),
         ])
-        client.applyEventsForTesting([
+        client.applyEvents([
             makeUpdateEvent(
                 resource: HueEventResource(
                     id: validId,
@@ -347,7 +408,7 @@ struct HueAPIClientTests {
 
         // Act
         client.previewBrightness(groupedLightId: validId, brightness: 40.0)
-        client.applyEventsForTesting([
+        client.applyEvents([
             makeUpdateEvent(
                 resource: HueEventResource(
                     id: validId,
@@ -686,11 +747,90 @@ struct HueAPIClientTests {
     }
 
     private func makeUpdateEvent(resource: HueEventResource) -> HueEvent {
+        makeUpdateEvent(resources: [resource])
+    }
+
+    private func makeUpdateEvent(resources: [HueEventResource]) -> HueEvent {
         HueEvent(
             creationtime: "2024-01-01T00:00:00Z",
             id: UUID().uuidString,
             type: .update,
-            data: [resource]
+            data: resources
         )
+    }
+
+    private func createEventStreamReconnectContext() -> (
+        client: HueAPIClient,
+        groupedLightRequestCount: () -> Int,
+        eventStreamRequestCount: () -> Int
+    ) {
+        let client = makeClient()
+        let groupedLightId = "00000000-0000-0000-0000-000000000099"
+        let lock = NSLock()
+        var groupedLightRequestCount = 0
+        var eventStreamRequestCount = 0
+
+        MockURLProtocol.requestHandler = { request in
+            let path = request.url?.path ?? ""
+            if path == "/eventstream/clip/v2" {
+                lock.lock()
+                eventStreamRequestCount += 1
+                let currentRequestCount = eventStreamRequestCount
+                lock.unlock()
+
+                if currentRequestCount == 1 {
+                    throw URLError(.networkConnectionLost)
+                }
+
+                let response = HTTPURLResponse(
+                    url: request.url!,
+                    statusCode: 200,
+                    httpVersion: nil,
+                    headerFields: ["Content-Type": "text/event-stream"]
+                )!
+                return (response, Data(": keepalive\n\n".utf8))
+            }
+
+            let json: String
+            if path.hasSuffix("/grouped_light") {
+                lock.lock()
+                groupedLightRequestCount += 1
+                let isOn = groupedLightRequestCount == 1
+                lock.unlock()
+
+                json = """
+                {"errors":[],"data":[
+                    {"id":"\(groupedLightId)","on":{"on":\(isOn)},"dimming":{"brightness":80.0}}
+                ]}
+                """
+            } else {
+                json = #"{"errors":[],"data":[]}"#
+            }
+
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (response, Data(json.utf8))
+        }
+
+        return (
+            client: client,
+            groupedLightRequestCount: {
+                lock.lock()
+                defer { lock.unlock() }
+                return groupedLightRequestCount
+            },
+            eventStreamRequestCount: {
+                lock.lock()
+                defer { lock.unlock() }
+                return eventStreamRequestCount
+            }
+        )
+    }
+
+    private func waitUntil(_ condition: @escaping @MainActor () -> Bool) async -> Bool {
+        for _ in 0..<80 {
+            if condition() { return true }
+            try? await Task.sleep(for: .milliseconds(50))
+        }
+        return condition()
     }
 }

--- a/Tests/HueBarTests/HueAPIClientTests.swift
+++ b/Tests/HueBarTests/HueAPIClientTests.swift
@@ -190,7 +190,7 @@ struct HueAPIClientTests {
         ]
 
         // Act
-        client.applyEventsForTesting([
+        client.applyEvents([
             makeUpdateEvent(resources: [
                 HueEventResource(
                     id: lightId,


### PR DESCRIPTION
HueBar was relying on the SSE stream after the initial fetch, but if that stream dropped and reconnected, we weren't doing a full state reconciliation. So if a light changed while HueBar was disconnected from events, for example via the Hue app or a physical button, the UI could keep showing the old room state until something else forced a refresh.

There was also a related stale state path where Hue can send a `light` update without a matching `grouped_light` update. Since the menu rows are mostly backed by `grouped_light`, the individual light state could update while the room row still looked on.

This PR:
- emits a reconnect signal from `EventStreamConnection` after a failed or ended stream reconnects
- makes `HueAPIClient` run `fetchAll()` on that reconnect, so missed bridge changes get reconciled
- updates containing room/zone `grouped_light` state when individual `light` events arrive
- parses the event-stream host/port with `IPValidation.parseHostPort()`, so SSE also works with mock bridge addresses like `127.0.0.1:8080` and avoids unsafe colon-splitting for IPv6-style inputs
- adds tests for both the reconnect resync and the grouped-light stale state case
