### PR TITLE
fix: sync optimistic light and room toggles

### DIFF
--- a/Sources/HueBar/Services/HueAPIClient.swift
+++ b/Sources/HueBar/Services/HueAPIClient.swift
@@ -155,7 +155,7 @@ final class HueAPIClient {
         let (_, response) = try await session.data(for: request)
         guard let httpResponse = response as? HTTPURLResponse,
               (200...299).contains(httpResponse.statusCode) else {
-            optimisticUpdates.clear(.on, for: .light, id: id)
+            clearOptimisticLightToggle(id: id)
             lights = try await fetchLights()
             throw HueAPIError.invalidResponse
         }
@@ -255,7 +255,9 @@ final class HueAPIClient {
         guard Self.isValidResourceId(id) else {
             throw HueAPIError.invalidResourceId
         }
+        let memberLightIds = lightIds(inGroupedLight: id)
         applyGroupedLightOnOptimistically(id: id, on: on)
+        optimisticallyUpdateLights(withIds: memberLightIds, on: on)
 
         let request = try makeRequest(
             path: "grouped_light/\(id)",
@@ -266,8 +268,12 @@ final class HueAPIClient {
         guard let httpResponse = response as? HTTPURLResponse,
               (200...299).contains(httpResponse.statusCode) else {
             // Revert on failure
-            optimisticUpdates.clear(.on, for: .groupedLight, id: id)
+            clearOptimisticGroupedLightToggle(id: id)
+            clearOptimisticLightToggles(withIds: memberLightIds)
             groupedLights = try await fetchGroupedLights()
+            if !memberLightIds.isEmpty {
+                lights = try await fetchLights()
+            }
             throw HueAPIError.invalidResponse
         }
     }
@@ -545,6 +551,7 @@ final class HueAPIClient {
         if let index = lights.firstIndex(where: { $0.id == id }) {
             lights[index].on = OnState(on: on)
             if !on, lights[index].dimming != nil {
+                optimisticUpdates.record(.brightness(0), for: .light, id: id)
                 lights[index].dimming = DimmingState(brightness: 0)
             }
         }
@@ -582,8 +589,53 @@ final class HueAPIClient {
         if let index = groupedLights.firstIndex(where: { $0.id == id }) {
             groupedLights[index].on = OnState(on: on)
             if !on, groupedLights[index].dimming != nil {
+                optimisticUpdates.record(.brightness(0), for: .groupedLight, id: id)
                 groupedLights[index].dimming = DimmingState(brightness: 0)
             }
+        }
+    }
+
+    private func optimisticallyUpdateLights(withIds lightIds: Set<String>, on: Bool) {
+        guard !lightIds.isEmpty else { return }
+
+        for index in lights.indices where lightIds.contains(lights[index].id) {
+            let lightId = lights[index].id
+            optimisticUpdates.record(.on(on), for: .light, id: lightId)
+            lights[index].on = OnState(on: on)
+            if !on, lights[index].dimming != nil {
+                optimisticUpdates.record(.brightness(0), for: .light, id: lightId)
+                lights[index].dimming = DimmingState(brightness: 0)
+            }
+        }
+    }
+
+    private func lightIds(inGroupedLight groupedLightId: String) -> Set<String> {
+        var lightIds = Set<String>()
+
+        for room in rooms where room.groupedLightId == groupedLightId {
+            lightIds.formUnion(lights(forRoom: room).map(\.id))
+        }
+
+        for zone in zones where zone.groupedLightId == groupedLightId {
+            lightIds.formUnion(lights(forZone: zone).map(\.id))
+        }
+
+        return lightIds
+    }
+
+    private func clearOptimisticLightToggle(id: String) {
+        optimisticUpdates.clear(.on, for: .light, id: id)
+        optimisticUpdates.clear(.brightness, for: .light, id: id)
+    }
+
+    private func clearOptimisticGroupedLightToggle(id: String) {
+        optimisticUpdates.clear(.on, for: .groupedLight, id: id)
+        optimisticUpdates.clear(.brightness, for: .groupedLight, id: id)
+    }
+
+    private func clearOptimisticLightToggles(withIds lightIds: Set<String>) {
+        for lightId in lightIds {
+            clearOptimisticLightToggle(id: lightId)
         }
     }
 

--- a/Sources/HueBar/Services/HueAPIClient.swift
+++ b/Sources/HueBar/Services/HueAPIClient.swift
@@ -544,6 +544,9 @@ final class HueAPIClient {
         optimisticUpdates.record(.on(on), for: .light, id: id)
         if let index = lights.firstIndex(where: { $0.id == id }) {
             lights[index].on = OnState(on: on)
+            if !on, lights[index].dimming != nil {
+                lights[index].dimming = DimmingState(brightness: 0)
+            }
         }
     }
 
@@ -578,6 +581,9 @@ final class HueAPIClient {
         optimisticUpdates.record(.on(on), for: .groupedLight, id: id)
         if let index = groupedLights.firstIndex(where: { $0.id == id }) {
             groupedLights[index].on = OnState(on: on)
+            if !on, groupedLights[index].dimming != nil {
+                groupedLights[index].dimming = DimmingState(brightness: 0)
+            }
         }
     }
 

--- a/Tests/HueBarTests/HueAPIClientTests.swift
+++ b/Tests/HueBarTests/HueAPIClientTests.swift
@@ -214,6 +214,93 @@ struct HueAPIClientTests {
         #expect(client.groupedLights.first?.brightness == 35)
     }
 
+    @Test func toggleGroupedLightOffOptimisticallyUpdatesRoomLights() async throws {
+        // Arrange
+        let client = makeClient()
+        let groupedLightId = "00000000-0000-0000-0000-000000000003"
+        client.rooms = [
+            Room(
+                id: "office-room",
+                metadata: GroupMetadata(name: "Office", archetype: "office"),
+                services: [ResourceLink(rid: groupedLightId, rtype: "grouped_light")],
+                children: [
+                    ResourceLink(rid: "office-device-1", rtype: "device"),
+                    ResourceLink(rid: "office-device-2", rtype: "device"),
+                ]
+            ),
+        ]
+        client.groupedLights = [
+            GroupedLight(id: groupedLightId, on: OnState(on: true), dimming: DimmingState(brightness: 80.0), colorTemperature: nil),
+        ]
+        client.lights = [
+            makeLight(id: "office-light-1", name: "Office Desk", ownerRid: "office-device-1"),
+            makeLight(id: "office-light-2", name: "Office Ceiling", ownerRid: "office-device-2"),
+            makeLight(id: "kitchen-light-1", name: "Kitchen", ownerRid: "kitchen-device-1"),
+        ]
+
+        MockURLProtocol.requestHandler = { request in
+            #expect(request.httpMethod == "PUT")
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (response, Data())
+        }
+
+        // Act
+        try await client.toggleGroupedLight(id: groupedLightId, on: false)
+
+        // Assert
+        let officeLights = client.lights.filter { $0.id.hasPrefix("office-light") }
+        #expect(officeLights.allSatisfy { $0.isOn == false })
+        #expect(officeLights.allSatisfy { $0.brightness == 0 })
+        #expect(client.lights.first(where: { $0.id == "kitchen-light-1" })?.isOn == true)
+        #expect(client.lights.first(where: { $0.id == "kitchen-light-1" })?.brightness == 50)
+    }
+
+    @Test func toggleGroupedLightOnOptimisticallyUpdatesRoomLights() async throws {
+        // Arrange
+        let client = makeClient()
+        let groupedLightId = "00000000-0000-0000-0000-000000000004"
+        client.rooms = [
+            Room(
+                id: "office-room",
+                metadata: GroupMetadata(name: "Office", archetype: "office"),
+                services: [ResourceLink(rid: groupedLightId, rtype: "grouped_light")],
+                children: [
+                    ResourceLink(rid: "office-device-1", rtype: "device"),
+                    ResourceLink(rid: "office-device-2", rtype: "device"),
+                ]
+            ),
+        ]
+        client.groupedLights = [
+            GroupedLight(id: groupedLightId, on: OnState(on: false), dimming: DimmingState(brightness: 35.0), colorTemperature: nil),
+        ]
+        client.lights = [
+            makeLight(id: "office-light-1", name: "Office Desk", ownerRid: "office-device-1"),
+            makeLight(id: "office-light-2", name: "Office Ceiling", ownerRid: "office-device-2"),
+            makeLight(id: "kitchen-light-1", name: "Kitchen", ownerRid: "kitchen-device-1"),
+        ]
+        client.lights[0].on = OnState(on: false)
+        client.lights[0].dimming = DimmingState(brightness: 25)
+        client.lights[1].on = OnState(on: false)
+        client.lights[1].dimming = DimmingState(brightness: 45)
+        client.lights[2].on = OnState(on: false)
+
+        MockURLProtocol.requestHandler = { request in
+            #expect(request.httpMethod == "PUT")
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (response, Data())
+        }
+
+        // Act
+        try await client.toggleGroupedLight(id: groupedLightId, on: true)
+
+        // Assert
+        let officeLights = client.lights.filter { $0.id.hasPrefix("office-light") }
+        #expect(officeLights.allSatisfy { $0.isOn == true })
+        #expect(client.lights.first(where: { $0.id == "office-light-1" })?.brightness == 25)
+        #expect(client.lights.first(where: { $0.id == "office-light-2" })?.brightness == 45)
+        #expect(client.lights.first(where: { $0.id == "kitchen-light-1" })?.isOn == false)
+    }
+
     @Test func fetchRoomsHTTPError() async throws {
         let client = makeClient()
         MockURLProtocol.requestHandler = { request in

--- a/Tests/HueBarTests/HueAPIClientTests.swift
+++ b/Tests/HueBarTests/HueAPIClientTests.swift
@@ -151,6 +151,7 @@ struct HueAPIClientTests {
     }
 
     @Test func toggleGroupedLightOptimisticUpdate() async throws {
+        // Arrange
         let client = makeClient()
         let validId = "00000000-0000-0000-0000-000000000001"
         client.groupedLights = [
@@ -184,9 +185,33 @@ struct HueAPIClientTests {
             return (response, Data())
         }
 
+        // Act
         try await client.toggleGroupedLight(id: validId, on: false)
         #expect(observedStateBeforeResponse.get() == false)
         #expect(client.groupedLights.first?.isOn == false)
+        #expect(client.groupedLights.first?.brightness == 0)
+    }
+
+    @Test func toggleGroupedLightOnPreservesOptimisticBrightness() async throws {
+        // Arrange
+        let client = makeClient()
+        let validId = "00000000-0000-0000-0000-000000000002"
+        client.groupedLights = [
+            GroupedLight(id: validId, on: OnState(on: false), dimming: DimmingState(brightness: 35.0), colorTemperature: nil),
+        ]
+
+        MockURLProtocol.requestHandler = { request in
+            #expect(request.httpMethod == "PUT")
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (response, Data())
+        }
+
+        // Act
+        try await client.toggleGroupedLight(id: validId, on: true)
+
+        // Assert
+        #expect(client.groupedLights.first?.isOn == true)
+        #expect(client.groupedLights.first?.brightness == 35)
     }
 
     @Test func fetchRoomsHTTPError() async throws {
@@ -423,6 +448,7 @@ struct HueAPIClientTests {
     // MARK: - Light control tests
 
     @Test func toggleLightOptimisticUpdate() async throws {
+        // Arrange
         let client = makeClient()
         let validId = "00000000-0000-0000-0000-000000000001"
         client.lights = [makeLight(id: validId, name: "Lamp", ownerRid: "device-A")]
@@ -441,9 +467,34 @@ struct HueAPIClientTests {
             return (response, Data())
         }
 
+        // Act
         try await client.toggleLight(id: validId, on: false)
         #expect(observedStateBeforeResponse.get() == false)
         #expect(client.lights.first?.isOn == false)
+        #expect(client.lights.first?.brightness == 0)
+    }
+
+    @Test func toggleLightOnPreservesOptimisticBrightness() async throws {
+        // Arrange
+        let client = makeClient()
+        let validId = "00000000-0000-0000-0000-000000000002"
+        client.lights = [makeLight(id: validId, name: "Lamp", ownerRid: "device-A")]
+        client.lights[0].on = OnState(on: false)
+        client.lights[0].dimming = DimmingState(brightness: 35)
+
+        MockURLProtocol.requestHandler = { request in
+            #expect(request.httpMethod == "PUT")
+            #expect(request.url?.absoluteString.contains("/clip/v2/resource/light/\(validId)") == true)
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (response, Data())
+        }
+
+        // Act
+        try await client.toggleLight(id: validId, on: true)
+
+        // Assert
+        #expect(client.lights.first?.isOn == true)
+        #expect(client.lights.first?.brightness == 35)
     }
 
     @Test func setLightBrightnessClamping() async throws {


### PR DESCRIPTION
When toggling a light or room off, HueBar was only updating the local `on` state optimistically. The brightness stayed at the previous value until the bridge response or follow-up events came back, so the UI could show the toggle as off while the brightness control still looked like it was sitting at 50% or 80% for a second.

There was a related room/zone issue too: toggling the `grouped_light` updated the row state, but the known member lights could keep their old local state until bridge events arrived.

This PR:
- sets local brightness to `0` immediately when an individual `light` is optimistically toggled off
- does the same for room/zone `grouped_light` toggles
- updates known member lights when a room/zone `grouped_light` is optimistically toggled, so light rows don't wait for SSE to catch up
- preserves the current brightness when toggling on, because HueBar doesn't know what brightness the bridge will restore yet
- adds tests for off-to-zero, on-preserves-brightness, and grouped-light member updates

<details>
<summary>Off Brightness Before</summary>

https://github.com/user-attachments/assets/d7e82dec-62c1-4a6f-adb9-0131a920cfa1

</details>

<details>
<summary>Off Brightness After</summary>

https://github.com/user-attachments/assets/746fd529-8896-4f57-b41b-8228366edb55

</details>

<details>
<summary>Toggle Group Before</summary>

https://github.com/user-attachments/assets/5e48066c-fa1d-466e-85fa-f37db36d4d1e

</details>

<details>
<summary>Toggle Group After</summary>

https://github.com/user-attachments/assets/496bb6df-fe8e-4434-b33b-abdcb160d6bb

</details>

