### PR TITLE
fix(ui): use current light colors for previews

### DIFF
--- a/Sources/HueBar/Models/Light.swift
+++ b/Sources/HueBar/Models/Light.swift
@@ -22,24 +22,24 @@ struct HueLight: Decodable, Sendable, Identifiable {
     /// Vivid color for display indicators (colored dots)
     var displayColor: Color {
         if let xy = color?.xy {
-            return xy.displayColor()
+            return xy.displayColor(brightness: dimming?.brightness)
         }
         if let mirek = colorTemperature?.mirek {
-            return CIEXYColor.colorFromMirek(mirek)
+            return CIEXYColor.colorFromMirek(mirek, brightness: dimming?.brightness)
         }
-        return CIEXYColor.colorFromMirek(370)
+        return CIEXYColor.colorFromMirek(370, brightness: dimming?.brightness)
     }
 
     /// Current color as a SwiftUI Color for card backgrounds
     var currentColor: Color {
         if let xy = color?.xy {
-            return xy.swiftUIColor()
+            return xy.swiftUIColor(brightness: dimming?.brightness)
         }
         if let mirek = colorTemperature?.mirek {
-            return CIEXYColor.colorFromMirek(mirek)
+            return CIEXYColor.colorFromMirek(mirek, brightness: dimming?.brightness)
         }
         // White-only light fallback
-        return CIEXYColor.colorFromMirek(370)
+        return CIEXYColor.colorFromMirek(370, brightness: dimming?.brightness)
     }
 
     var supportsColor: Bool { color != nil }

--- a/Sources/HueBar/Models/Scene.swift
+++ b/Sources/HueBar/Models/Scene.swift
@@ -4,7 +4,7 @@ import Foundation
 /// View-layer code converts these to `Color` via the extension in SceneColorExtension.swift.
 enum ScenePaletteEntry: Sendable {
     case xy(CIEXYColor, brightness: Double?)
-    case colorTemperature(mirek: Int)
+    case colorTemperature(mirek: Int, brightness: Double?)
 }
 
 struct HueScene: Decodable, Sendable, Identifiable {
@@ -54,7 +54,7 @@ struct HueScene: Decodable, Sendable, Identifiable {
         if let temps = palette.colorTemperature, !temps.isEmpty {
             return temps.compactMap { entry in
                 guard let mirek = entry.colorTemperature?.mirek else { return nil }
-                return .colorTemperature(mirek: mirek)
+                return .colorTemperature(mirek: mirek, brightness: entry.dimming?.brightness)
             }
         }
 

--- a/Sources/HueBar/Services/HueAPIClient.swift
+++ b/Sources/HueBar/Services/HueAPIClient.swift
@@ -347,17 +347,43 @@ final class HueAPIClient {
     }
 
     /// Get the raw palette entries for a room/zone card.
-    /// Prefers the active scene, falls back to the first scene with palette entries.
-    func activeScenePaletteEntries(for groupId: String?) -> [ScenePaletteEntry] {
+    /// Prefers current on-light state, falls back only to a known active scene.
+    func previewPaletteEntries(for groupId: String?) -> [ScenePaletteEntry] {
         guard let groupId else { return [] }
-        // Use active scene if we know it
+        let currentEntries = currentLightPaletteEntries(for: groupId)
+        if !currentEntries.isEmpty {
+            return currentEntries
+        }
+
         if let active = activeScene(for: groupId), !active.paletteEntries.isEmpty {
             return active.paletteEntries
         }
-        // Fall back: use the first scene for this group that has palette entries
-        let groupScenes = scenes.filter { $0.group.rid == groupId }
-        if let withPalette = groupScenes.first(where: { !$0.paletteEntries.isEmpty }) {
-            return withPalette.paletteEntries
+
+        return []
+    }
+
+    private func currentLightPaletteEntries(for groupId: String) -> [ScenePaletteEntry] {
+        lights(forGroupId: groupId).compactMap { light in
+            guard light.isOn else { return nil }
+            if let xy = light.color?.xy {
+                return .xy(xy, brightness: light.dimming?.brightness)
+            }
+            if let mirek = light.colorTemperature?.mirek {
+                return .colorTemperature(mirek: mirek)
+            }
+            if light.dimming != nil {
+                return .colorTemperature(mirek: 370)
+            }
+            return nil
+        }
+    }
+
+    private func lights(forGroupId groupId: String) -> [HueLight] {
+        if let room = rooms.first(where: { $0.id == groupId }) {
+            return lights(forRoom: room)
+        }
+        if let zone = zones.first(where: { $0.id == groupId }) {
+            return lights(forZone: zone)
         }
         return []
     }

--- a/Sources/HueBar/Services/HueAPIClient.swift
+++ b/Sources/HueBar/Services/HueAPIClient.swift
@@ -20,6 +20,9 @@ enum HueAPIError: Error, LocalizedError {
 @Observable
 @MainActor
 final class HueAPIClient {
+    /// Warm-white fallback for on, dimmable lights that do not report color temperature.
+    private static let defaultWarmWhiteMirek = 370
+
     var rooms: [Room] = []
     var zones: [Zone] = []
     var groupedLights: [GroupedLight] = []
@@ -369,10 +372,10 @@ final class HueAPIClient {
                 return .xy(xy, brightness: light.dimming?.brightness)
             }
             if let mirek = light.colorTemperature?.mirek {
-                return .colorTemperature(mirek: mirek)
+                return .colorTemperature(mirek: mirek, brightness: light.dimming?.brightness)
             }
             if light.dimming != nil {
-                return .colorTemperature(mirek: 370)
+                return .colorTemperature(mirek: Self.defaultWarmWhiteMirek, brightness: light.dimming?.brightness)
             }
             return nil
         }

--- a/Sources/HueBar/Utilities/ColorConversion.swift
+++ b/Sources/HueBar/Utilities/ColorConversion.swift
@@ -69,12 +69,16 @@ extension CIEXYColor {
         if warmHue < 0 { warmHue += 1 }
         if warmHue > 1 { warmHue -= 1 }
 
-        return Color(hue: warmHue, saturation: min(sat, 0.85), brightness: 0.70)
+        return Color(
+            hue: warmHue,
+            saturation: min(sat, 0.85),
+            brightness: Self.previewBrightness(from: brightness, default: 0.70)
+        )
     }
 
     /// Convert mirek color temperature to an approximate color.
     /// Mirek range: 153 (cool/blue, 6500K) to 500 (warm/orange, 2000K).
-    static func colorFromMirek(_ mirek: Int) -> Color {
+    static func colorFromMirek(_ mirek: Int, brightness: Double? = nil) -> Color {
         let kelvin = 1_000_000.0 / Double(max(mirek, 153))
         let temp = kelvin / 100.0
 
@@ -113,7 +117,23 @@ extension CIEXYColor {
         g = g + (1.0 - g) * mix
         b = b + (1.0 - b) * mix
 
+        if brightness != nil {
+            let maxComponent = max(r, g, b, 0.0001)
+            let targetBrightness = Self.previewBrightness(from: brightness, default: maxComponent)
+            let scale = targetBrightness / maxComponent
+            r *= scale
+            g *= scale
+            b *= scale
+        }
+
         return Color(red: r, green: g, blue: b)
+    }
+
+    private static func previewBrightness(from brightness: Double?, default defaultBrightness: Double) -> Double {
+        guard let brightness else { return defaultBrightness }
+        let normalized = min(max(brightness, 1), 100) / 100
+        let minimumVisibleBrightness = 0.30
+        return minimumVisibleBrightness + ((defaultBrightness - minimumVisibleBrightness) * normalized)
     }
 
     /// Convert HSB (hue/saturation/brightness all 0…1) to CIE xy.

--- a/Sources/HueBar/Utilities/ColorConversion.swift
+++ b/Sources/HueBar/Utilities/ColorConversion.swift
@@ -132,6 +132,7 @@ extension CIEXYColor {
     private static func previewBrightness(from brightness: Double?, default defaultBrightness: Double) -> Double {
         guard let brightness else { return defaultBrightness }
         let normalized = min(max(brightness, 1), 100) / 100
+        // Keep barely-on lights visible in dark cards while still preserving relative brightness.
         let minimumVisibleBrightness = 0.30
         return minimumVisibleBrightness + ((defaultBrightness - minimumVisibleBrightness) * normalized)
     }

--- a/Sources/HueBar/Utilities/ColorConversion.swift
+++ b/Sources/HueBar/Utilities/ColorConversion.swift
@@ -30,9 +30,15 @@ extension CIEXYColor {
     }
 
     /// Vivid color for display indicators (colored dots, previews).
-    func displayColor() -> Color {
+    func displayColor(brightness: Double? = nil) -> Color {
         let rgb = toSRGB()
-        return Color(red: rgb.r, green: rgb.g, blue: rgb.b)
+        guard brightness != nil else {
+            return Color(red: rgb.r, green: rgb.g, blue: rgb.b)
+        }
+        let maxComponent = max(rgb.r, rgb.g, rgb.b, 0.0001)
+        let targetBrightness = Self.previewBrightness(from: brightness, default: maxComponent)
+        let scale = targetBrightness / maxComponent
+        return Color(red: rgb.r * scale, green: rgb.g * scale, blue: rgb.b * scale)
     }
 
     /// Convert CIE 1931 xy + brightness to sRGB SwiftUI Color.

--- a/Sources/HueBar/Views/LightRowView.swift
+++ b/Sources/HueBar/Views/LightRowView.swift
@@ -106,7 +106,7 @@ struct LightRowView: View {
         guard isOn else {
             return AnyShapeStyle(Color.hueCardOff)
         }
-        let colors = apiClient.activeSceneColors(for: groupId)
+        let colors = apiClient.previewColors(for: groupId)
         if colors.count >= 2 {
             return AnyShapeStyle(
                 LinearGradient(colors: colors, startPoint: .topLeading, endPoint: .bottomTrailing)

--- a/Sources/HueBar/Views/SceneColorExtension.swift
+++ b/Sources/HueBar/Views/SceneColorExtension.swift
@@ -21,7 +21,7 @@ extension HueScene {
 
 extension HueAPIClient {
     /// Convenience for views: converts raw palette entries to SwiftUI Colors.
-    func activeSceneColors(for groupId: String?) -> [Color] {
-        activeScenePaletteEntries(for: groupId).map(\.color)
+    func previewColors(for groupId: String?) -> [Color] {
+        previewPaletteEntries(for: groupId).map(\.color)
     }
 }

--- a/Sources/HueBar/Views/SceneColorExtension.swift
+++ b/Sources/HueBar/Views/SceneColorExtension.swift
@@ -6,7 +6,7 @@ extension ScenePaletteEntry {
         switch self {
         case .xy(let xy, let brightness):
             return xy.swiftUIColor(brightness: brightness)
-        case .colorTemperature(let mirek):
+        case .colorTemperature(let mirek, _):
             return CIEXYColor.colorFromMirek(mirek)
         }
     }

--- a/Sources/HueBar/Views/SceneColorExtension.swift
+++ b/Sources/HueBar/Views/SceneColorExtension.swift
@@ -6,8 +6,8 @@ extension ScenePaletteEntry {
         switch self {
         case .xy(let xy, let brightness):
             return xy.swiftUIColor(brightness: brightness)
-        case .colorTemperature(let mirek, _):
-            return CIEXYColor.colorFromMirek(mirek)
+        case .colorTemperature(let mirek, let brightness):
+            return CIEXYColor.colorFromMirek(mirek, brightness: brightness)
         }
     }
 }

--- a/Tests/HueBarTests/ColorConversionTests.swift
+++ b/Tests/HueBarTests/ColorConversionTests.swift
@@ -90,6 +90,37 @@ struct ColorConversionTests {
         #expect(dim.brightness > 0.25)
     }
 
+    @Test("HueLight displayColor reflects dimming brightness")
+    func hueLightDisplayColorReflectsBrightness() {
+        // Arrange
+        let xy = CIEXYColor(x: 0.4595, y: 0.4105)
+        let dimLight = makeLight(xy: xy, brightness: 5)
+        let brightLight = makeLight(xy: xy, brightness: 100)
+
+        // Act
+        let dim = extractHSB(from: dimLight.displayColor)
+        let bright = extractHSB(from: brightLight.displayColor)
+
+        // Assert
+        #expect(dim.brightness < bright.brightness)
+        #expect(dim.brightness > 0.25)
+    }
+
+    @Test("HueLight currentColor reflects dimming brightness")
+    func hueLightCurrentColorReflectsBrightness() {
+        // Arrange
+        let dimLight = makeLight(mirek: 370, brightness: 5)
+        let brightLight = makeLight(mirek: 370, brightness: 100)
+
+        // Act
+        let dim = extractHSB(from: dimLight.currentColor)
+        let bright = extractHSB(from: brightLight.currentColor)
+
+        // Assert
+        #expect(dim.brightness < bright.brightness)
+        #expect(dim.brightness > 0.25)
+    }
+
     // MARK: - displayColor()
 
     @Test("displayColor returns a valid color for a known CIE point")
@@ -206,5 +237,21 @@ struct ColorConversionTests {
         }
         let sat = maxC > 0 ? delta / maxC : 0
         return (hue: hue, saturation: sat, brightness: maxC)
+    }
+
+    private func makeLight(
+        xy: CIEXYColor? = nil,
+        mirek: Int? = nil,
+        brightness: Double
+    ) -> HueLight {
+        HueLight(
+            id: "light-1",
+            owner: ResourceLink(rid: "device-1", rtype: "device"),
+            metadata: LightMetadata(name: "Desk", archetype: "table_wash"),
+            on: OnState(on: true),
+            dimming: DimmingState(brightness: brightness),
+            color: xy.map { LightColor(xy: $0) },
+            colorTemperature: mirek.map { LightColorTemperature(mirek: $0, mirekValid: true) }
+        )
     }
 }

--- a/Tests/HueBarTests/ColorConversionTests.swift
+++ b/Tests/HueBarTests/ColorConversionTests.swift
@@ -62,6 +62,34 @@ struct ColorConversionTests {
         #expect(hsb.brightness > 0.8, "Cool mirek should be bright")
     }
 
+    @Test("swiftUIColor reflects preview brightness")
+    func swiftUIColorReflectsPreviewBrightness() {
+        // Arrange
+        let warm = CIEXYColor(x: 0.4595, y: 0.4105)
+
+        // Act
+        let dim = extractHSB(from: warm.swiftUIColor(brightness: 5))
+        let bright = extractHSB(from: warm.swiftUIColor(brightness: 100))
+
+        // Assert
+        #expect(dim.brightness < bright.brightness)
+        #expect(dim.brightness > 0.25)
+    }
+
+    @Test("colorFromMirek reflects preview brightness")
+    func colorFromMirekReflectsPreviewBrightness() {
+        // Arrange
+        let mirek = 370
+
+        // Act
+        let dim = extractHSB(from: CIEXYColor.colorFromMirek(mirek, brightness: 5))
+        let bright = extractHSB(from: CIEXYColor.colorFromMirek(mirek, brightness: 100))
+
+        // Assert
+        #expect(dim.brightness < bright.brightness)
+        #expect(dim.brightness > 0.25)
+    }
+
     // MARK: - displayColor()
 
     @Test("displayColor returns a valid color for a known CIE point")

--- a/Tests/HueBarTests/HueAPIClientTests.swift
+++ b/Tests/HueBarTests/HueAPIClientTests.swift
@@ -390,17 +390,61 @@ struct HueAPIClientTests {
 
     // MARK: - activeScene(for:) tests
 
-    private func makeScene(id: String, name: String, groupId: String, status: HueSceneActiveState?, speed: Double? = nil, autoDynamic: Bool? = nil) -> HueScene {
+    private func makeScene(
+        id: String,
+        name: String,
+        groupId: String,
+        status: HueSceneActiveState?,
+        palette: HueScenePalette? = nil,
+        speed: Double? = nil,
+        autoDynamic: Bool? = nil
+    ) -> HueScene {
         HueScene(
             id: id,
             type: "scene",
             metadata: HueSceneMetadata(name: name, image: nil),
             group: ResourceLink(rid: groupId, rtype: "room"),
             status: status.map { HueSceneStatus(active: $0) },
-            palette: nil,
+            palette: palette,
             speed: speed,
             autoDynamic: autoDynamic
         )
+    }
+
+    private func makeColorPalette(_ colors: [CIEXYColor]) -> HueScenePalette {
+        HueScenePalette(
+            color: colors.map { HueScenePaletteColor(color: HueColorValue(xy: $0), dimming: nil) },
+            dimming: [],
+            colorTemperature: []
+        )
+    }
+
+    private func makeTemperaturePalette(_ mireks: [Int]) -> HueScenePalette {
+        HueScenePalette(
+            color: [],
+            dimming: [],
+            colorTemperature: mireks.map {
+                HueScenePaletteColorTemp(colorTemperature: HueColorTemperature(mirek: $0), dimming: nil)
+            }
+        )
+    }
+
+    private func mireks(in entries: [ScenePaletteEntry]) -> [Int] {
+        entries.compactMap { entry in
+            if case .colorTemperature(let mirek) = entry {
+                return mirek
+            }
+            return nil
+        }
+    }
+
+    private func xyCount(in entries: [ScenePaletteEntry]) -> Int {
+        entries.filter { entry in
+            if case .xy = entry {
+                return true
+            }
+            return false
+        }.count
     }
 
     @Test func activeSceneReturnsStaticScene() {
@@ -421,6 +465,75 @@ struct HueAPIClientTests {
         ]
 
         #expect(client.activeScene(for: "room-1") == nil)
+    }
+
+    @Test func previewPaletteUsesCurrentRoomLightsInsteadOfInactiveSceneFallback() {
+        // Arrange
+        let client = makeClient()
+        client.rooms = [
+            Room(
+                id: "room-1",
+                metadata: GroupMetadata(name: "Office", archetype: "office"),
+                services: [],
+                children: [
+                    ResourceLink(rid: "device-1", rtype: "device"),
+                    ResourceLink(rid: "device-2", rtype: "device"),
+                ]
+            ),
+        ]
+        client.lights = [
+            makeLight(id: "light-1", name: "Desk", ownerRid: "device-1", mirek: 370),
+            makeLight(id: "light-2", name: "Ceiling", ownerRid: "device-2", mirek: 370),
+        ]
+        client.scenes = [
+            makeScene(
+                id: "vapor-wave",
+                name: "Vapor Wave",
+                groupId: "room-1",
+                status: .inactive,
+                palette: makeColorPalette([
+                    CIEXYColor(x: 0.167, y: 0.04),
+                    CIEXYColor(x: 0.5, y: 0.2),
+                ])
+            ),
+            makeScene(
+                id: "bright",
+                name: "Bright",
+                groupId: "room-1",
+                status: .inactive,
+                palette: makeTemperaturePalette([370])
+            ),
+        ]
+
+        // Act
+        let entries = client.previewPaletteEntries(for: "room-1")
+
+        // Assert
+        #expect(mireks(in: entries) == [370, 370])
+        #expect(xyCount(in: entries) == 0)
+    }
+
+    @Test func previewPaletteDoesNotUseInactiveSceneWhenCurrentLightsAreUnknown() {
+        // Arrange
+        let client = makeClient()
+        client.scenes = [
+            makeScene(
+                id: "vapor-wave",
+                name: "Vapor Wave",
+                groupId: "room-1",
+                status: .inactive,
+                palette: makeColorPalette([
+                    CIEXYColor(x: 0.167, y: 0.04),
+                    CIEXYColor(x: 0.5, y: 0.2),
+                ])
+            ),
+        ]
+
+        // Act
+        let entries = client.previewPaletteEntries(for: "room-1")
+
+        // Assert
+        #expect(entries.isEmpty)
     }
 
     @Test func toggleLightRollbackOnHTTPFailure() async throws {
@@ -536,7 +649,7 @@ struct HueAPIClientTests {
         #expect(client.isActiveSceneDynamic(for: nil) == false)
     }
 
-    private func makeLight(id: String, name: String, ownerRid: String) -> HueLight {
+    private func makeLight(id: String, name: String, ownerRid: String, mirek: Int? = nil) -> HueLight {
         HueLight(
             id: id,
             owner: ResourceLink(rid: ownerRid, rtype: "device"),
@@ -544,7 +657,7 @@ struct HueAPIClientTests {
             on: OnState(on: true),
             dimming: DimmingState(brightness: 50),
             color: nil,
-            colorTemperature: nil
+            colorTemperature: mirek.map { LightColorTemperature(mirek: $0, mirekValid: true) }
         )
     }
 }

--- a/Tests/HueBarTests/HueAPIClientTests.swift
+++ b/Tests/HueBarTests/HueAPIClientTests.swift
@@ -419,19 +419,27 @@ struct HueAPIClientTests {
         )
     }
 
-    private func makeTemperaturePalette(_ mireks: [Int]) -> HueScenePalette {
+    private struct TemperatureStop: Equatable {
+        let mirek: Int
+        let brightness: Double?
+    }
+
+    private func makeTemperaturePalette(_ mireks: [Int], brightness: Double? = nil) -> HueScenePalette {
         HueScenePalette(
             color: [],
             dimming: [],
             colorTemperature: mireks.map {
-                HueScenePaletteColorTemp(colorTemperature: HueColorTemperature(mirek: $0), dimming: nil)
+                HueScenePaletteColorTemp(
+                    colorTemperature: HueColorTemperature(mirek: $0),
+                    dimming: brightness.map { HueScenePaletteDimming(brightness: $0) }
+                )
             }
         )
     }
 
     private func mireks(in entries: [ScenePaletteEntry]) -> [Int] {
         entries.compactMap { entry in
-            if case .colorTemperature(let mirek) = entry {
+            if case .colorTemperature(let mirek, _) = entry {
                 return mirek
             }
             return nil
@@ -445,6 +453,15 @@ struct HueAPIClientTests {
             }
             return false
         }.count
+    }
+
+    private func temperatureStops(in entries: [ScenePaletteEntry]) -> [TemperatureStop] {
+        entries.compactMap { entry in
+            if case .colorTemperature(let mirek, let brightness) = entry {
+                return TemperatureStop(mirek: mirek, brightness: brightness)
+            }
+            return nil
+        }
     }
 
     @Test func activeSceneReturnsStaticScene() {
@@ -534,6 +551,37 @@ struct HueAPIClientTests {
 
         // Assert
         #expect(entries.isEmpty)
+    }
+
+    @Test func previewPaletteUsesKnownActiveSceneWhenCurrentLightsAreUnavailable() {
+        // Arrange
+        let client = makeClient()
+        client.scenes = [
+            makeScene(
+                id: "vapor-wave",
+                name: "Vapor Wave",
+                groupId: "room-1",
+                status: .inactive,
+                palette: makeColorPalette([
+                    CIEXYColor(x: 0.167, y: 0.04),
+                    CIEXYColor(x: 0.5, y: 0.2),
+                ])
+            ),
+            makeScene(
+                id: "bright",
+                name: "Bright",
+                groupId: "room-1",
+                status: .static,
+                palette: makeTemperaturePalette([370], brightness: 100)
+            ),
+        ]
+
+        // Act
+        let entries = client.previewPaletteEntries(for: "room-1")
+
+        // Assert
+        #expect(temperatureStops(in: entries) == [TemperatureStop(mirek: 370, brightness: 100)])
+        #expect(xyCount(in: entries) == 0)
     }
 
     @Test func toggleLightRollbackOnHTTPFailure() async throws {


### PR DESCRIPTION
HueBar was using scene palettes for the room/zone card background. If it didn't know which scene was active, it fell back to the first scene in that room with palette entries. That meant an inactive scene like Vapor Wave could be used for the preview even when the actual lights were currently yellow(? not sure, protanopia colorblindness) from Bright.

This PR:
- builds room/zone preview gradients from the current on lights in the room or zone
- supports mixed colors by using each member light as a gradient stop instead of averaging them
- falls back to a known active scene palette only when current light colors are unavailable
- stops using inactive scene palettes as a generic preview fallback
- preserves palette brightness for preview colors, with a visibility floor so barely-on lights still show up in dark cards
- also makes scene picker swatches brightness-aware when the scene palette includes per-entry dimming
- makes individual light card colors brightness-aware too, so dimmed lights do not show full-intensity accents/backgrounds
- renames the preview color path so it no longer reads like it is strictly scene-based
- adds tests for the stale inactive-scene fallback case, active-scene fallback, brightness-aware preview colors, and brightness-aware light card colors

<details>
<summary>Before</summary>

<img width="360" alt="Before: room preview showing the wrong inactive scene gradient" src="https://github.com/user-attachments/assets/5ad214d9-445d-43cb-b43a-a55d04fb6281" />

</details>

<details>
<summary>After</summary>

<img width="360" alt="After: room preview uses current light colors" src="https://github.com/user-attachments/assets/77490301-7543-4341-a6a1-bcf856d154ac" />
<img width="360" alt="After: mixed room preview colors stay consistent with current lights" src="https://github.com/user-attachments/assets/bf8d361e-0f8d-474e-869f-3334c1cd0fc8" />

</details>
