### PR TITLE
fix(scene): apply dynamic speed changes live

### DIFF
--- a/Sources/HueBar/Services/HueAPIClient.swift
+++ b/Sources/HueBar/Services/HueAPIClient.swift
@@ -395,7 +395,7 @@ final class HueAPIClient {
             throw HueAPIError.invalidResourceId
         }
         let clamped = min(max(speed, 0.0), 1.0)
-        let shouldApplyToLiveScene = isSceneDynamicActive(id: id)
+        let isDynamicSceneLive = isSceneDynamicActive(id: id)
 
         // Save previous speed for rollback
         let previousSpeed = scenes.first(where: { $0.id == id })?.speed
@@ -415,7 +415,7 @@ final class HueAPIClient {
             throw HueAPIError.invalidResponse
         }
 
-        if shouldApplyToLiveScene {
+        if isDynamicSceneLive {
             try await sendSceneRecall(id: id, action: "dynamic_palette")
         }
     }
@@ -423,9 +423,7 @@ final class HueAPIClient {
     /// Whether the active scene for a group is in dynamic palette mode
     func isActiveSceneDynamic(for groupId: String?) -> Bool {
         guard let scene = activeScene(for: groupId) else { return false }
-        if scene.isDynamicActive { return true }
-        // Fall back to locally tracked state
-        return scene.id == activeSceneId && activeSceneIsDynamic
+        return isSceneDynamicActive(scene)
     }
 
     private func sendSceneRecall(id: String, action: String) async throws {
@@ -439,10 +437,16 @@ final class HueAPIClient {
     }
 
     private func isSceneDynamicActive(id: String) -> Bool {
-        if scenes.first(where: { $0.id == id })?.isDynamicActive == true {
-            return true
+        guard let scene = scenes.first(where: { $0.id == id }) else {
+            return activeSceneId == id && activeSceneIsDynamic
         }
-        return activeSceneId == id && activeSceneIsDynamic
+        return isSceneDynamicActive(scene)
+    }
+
+    private func isSceneDynamicActive(_ scene: HueScene) -> Bool {
+        if scene.isDynamicActive { return true }
+        // Fall back to locally tracked state.
+        return activeSceneId == scene.id && activeSceneIsDynamic
     }
 
     private func updateSceneSpeed(id: String, speed: Double) {

--- a/Sources/HueBar/Services/HueAPIClient.swift
+++ b/Sources/HueBar/Services/HueAPIClient.swift
@@ -376,16 +376,14 @@ final class HueAPIClient {
         let optimisticStatus = HueSceneStatus(active: dynamic ? .dynamicPalette : .active)
         updateSceneStatus(id: id, status: optimisticStatus)
         let action = dynamic ? "dynamic_palette" : "active"
-        let body = try JSONEncoder().encode(["recall": ["action": action]])
-        let request = try makeRequest(path: "scene/\(id)", method: "PUT", body: body)
-        let (_, response) = try await session.data(for: request)
-        guard let httpResponse = response as? HTTPURLResponse,
-              (200...299).contains(httpResponse.statusCode) else {
+        do {
+            try await sendSceneRecall(id: id, action: action)
+        } catch {
             // Rollback optimistic update
             activeSceneId = previousSceneId
             activeSceneIsDynamic = previousIsDynamic
             updateSceneStatus(id: id, status: previousStatus)
-            throw HueAPIError.invalidResponse
+            throw error
         }
         // Refresh grouped lights to reflect scene's brightness/on state
         groupedLights = try await fetchGroupedLights()
@@ -397,6 +395,7 @@ final class HueAPIClient {
             throw HueAPIError.invalidResourceId
         }
         let clamped = min(max(speed, 0.0), 1.0)
+        let shouldApplyToLiveScene = isSceneDynamicActive(id: id)
 
         // Save previous speed for rollback
         let previousSpeed = scenes.first(where: { $0.id == id })?.speed
@@ -415,6 +414,10 @@ final class HueAPIClient {
             }
             throw HueAPIError.invalidResponse
         }
+
+        if shouldApplyToLiveScene {
+            try await sendSceneRecall(id: id, action: "dynamic_palette")
+        }
     }
 
     /// Whether the active scene for a group is in dynamic palette mode
@@ -423,6 +426,23 @@ final class HueAPIClient {
         if scene.isDynamicActive { return true }
         // Fall back to locally tracked state
         return scene.id == activeSceneId && activeSceneIsDynamic
+    }
+
+    private func sendSceneRecall(id: String, action: String) async throws {
+        let body = try JSONEncoder().encode(["recall": ["action": action]])
+        let request = try makeRequest(path: "scene/\(id)", method: "PUT", body: body)
+        let (_, response) = try await session.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse,
+              (200...299).contains(httpResponse.statusCode) else {
+            throw HueAPIError.invalidResponse
+        }
+    }
+
+    private func isSceneDynamicActive(id: String) -> Bool {
+        if scenes.first(where: { $0.id == id })?.isDynamicActive == true {
+            return true
+        }
+        return activeSceneId == id && activeSceneIsDynamic
     }
 
     private func updateSceneSpeed(id: String, speed: Double) {

--- a/Tests/HueBarTests/HueAPIClientTests.swift
+++ b/Tests/HueBarTests/HueAPIClientTests.swift
@@ -524,6 +524,52 @@ struct HueAPIClientTests {
         #expect(client.scenes.first?.speed == 0.0)
     }
 
+    @Test func setSceneSpeedReRecallsActiveDynamicScene() async throws {
+        let client = makeClient()
+        let sceneId = "00000000-0000-0000-0000-000000000012"
+        client.scenes = [
+            makeScene(id: sceneId, name: "Dynamic", groupId: "room-1", status: .dynamicPalette, speed: 0.5)
+        ]
+
+        var sceneRequests: [[String: Any]] = []
+        MockURLProtocol.requestHandler = { request in
+            if request.url?.absoluteString.contains("/resource/scene/\(sceneId)") == true {
+                sceneRequests.append(self.jsonBody(from: request))
+            }
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (response, Data())
+        }
+
+        try await client.setSceneSpeed(id: sceneId, speed: 0.7)
+
+        #expect(sceneRequests.count == 2)
+        #expect(sceneRequests[0]["speed"] as? Double == 0.7)
+        let recall = sceneRequests.dropFirst().first?["recall"] as? [String: String]
+        #expect(recall?["action"] == "dynamic_palette")
+    }
+
+    @Test func setSceneSpeedDoesNotRecallInactiveScene() async throws {
+        let client = makeClient()
+        let sceneId = "00000000-0000-0000-0000-000000000013"
+        client.scenes = [
+            makeScene(id: sceneId, name: "Dynamic", groupId: "room-1", status: .inactive, speed: 0.5)
+        ]
+
+        var sceneRequests: [[String: Any]] = []
+        MockURLProtocol.requestHandler = { request in
+            if request.url?.absoluteString.contains("/resource/scene/\(sceneId)") == true {
+                sceneRequests.append(self.jsonBody(from: request))
+            }
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (response, Data())
+        }
+
+        try await client.setSceneSpeed(id: sceneId, speed: 0.7)
+
+        #expect(sceneRequests.count == 1)
+        #expect(sceneRequests[0]["speed"] as? Double == 0.7)
+    }
+
     @Test func isActiveSceneDynamicReturnsCorrectValues() {
         let client = makeClient()
         client.scenes = [
@@ -534,6 +580,26 @@ struct HueAPIClientTests {
         #expect(client.isActiveSceneDynamic(for: "room-1") == false)
         #expect(client.isActiveSceneDynamic(for: "room-2") == true)
         #expect(client.isActiveSceneDynamic(for: nil) == false)
+    }
+
+    private func jsonBody(from request: URLRequest) -> [String: Any] {
+        var bodyData = request.httpBody
+        if bodyData == nil, let stream = request.httpBodyStream {
+            stream.open()
+            let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: 1024)
+            defer {
+                buffer.deallocate()
+                stream.close()
+            }
+            let read = stream.read(buffer, maxLength: 1024)
+            if read > 0 { bodyData = Data(bytes: buffer, count: read) }
+        }
+        guard let bodyData,
+              let body = try? JSONSerialization.jsonObject(with: bodyData) as? [String: Any]
+        else {
+            return [:]
+        }
+        return body
     }
 
     private func makeLight(id: String, name: String, ownerRid: String) -> HueLight {


### PR DESCRIPTION
HueBar was updating the saved `speed` field on the scene resource, but the bridge does not apply that new speed to a dynamic scene that is already running. I verified this against a scene: the scene resource changed to `0.1`, but the live light `dynamics.speed` stayed at the previous value until the same scene was recalled in `dynamic_palette` mode again.

This PR:
- keeps saving the scene speed through `PUT /clip/v2/resource/scene/{id}`
- re-recalls the scene in `dynamic_palette` mode when that scene is currently active and dynamic, so the live lights pick up the new speed immediately
- avoids recalling inactive scenes, so editing an inactive scene's saved speed does not start it
- keeps the existing optimistic slider update and rollback behavior
- adds tests for both the active-dynamic and inactive-scene paths

I also tested the behavior against the real bridge.