### PR TITLE
fix(bridge): refresh state on menu open

### DIFF
--- a/Sources/HueBar/Services/BridgeConnection.swift
+++ b/Sources/HueBar/Services/BridgeConnection.swift
@@ -11,6 +11,8 @@ enum BridgeConnectionStatus: Sendable, Equatable {
 @Observable
 @MainActor
 final class BridgeConnection: Identifiable {
+    static let defaultRefreshInterval: TimeInterval = 30
+
     let id: String
     var name: String
     let client: HueAPIClient
@@ -19,19 +21,27 @@ final class BridgeConnection: Identifiable {
     private let initialRetryDelay: Duration
     /// Upper bound on the reconnect delay; exponential growth is clamped here.
     private let maxRetryDelay: Duration
+    /// Minimum time between user-triggered full refresh attempts.
+    private let minimumRefreshInterval: TimeInterval
+    private let currentDate: @MainActor () -> Date
     /// Number of consecutive failed connection attempts since the last successful connect.
     @ObservationIgnored private var retryAttempt: Int = 0
     @ObservationIgnored private var reconnectTask: Task<Void, Never>?
+    @ObservationIgnored private var lastFetchAllAttemptAt: Date?
 
     init(
         credentials: BridgeCredentials,
         initialRetryDelay: Duration = .seconds(5),
-        maxRetryDelay: Duration = .seconds(300)
+        maxRetryDelay: Duration = .seconds(300),
+        minimumRefreshInterval: TimeInterval = BridgeConnection.defaultRefreshInterval,
+        currentDate: @escaping @MainActor () -> Date = Date.init
     ) throws {
         self.id = credentials.id
         self.name = credentials.name
         self.initialRetryDelay = initialRetryDelay
         self.maxRetryDelay = maxRetryDelay
+        self.minimumRefreshInterval = minimumRefreshInterval
+        self.currentDate = currentDate
         self.client = try HueAPIClient(bridgeIP: credentials.bridgeIP, applicationKey: credentials.applicationKey)
     }
 
@@ -40,13 +50,17 @@ final class BridgeConnection: Identifiable {
         name: String,
         client: HueAPIClient,
         initialRetryDelay: Duration = .seconds(5),
-        maxRetryDelay: Duration = .seconds(300)
+        maxRetryDelay: Duration = .seconds(300),
+        minimumRefreshInterval: TimeInterval = BridgeConnection.defaultRefreshInterval,
+        currentDate: @escaping @MainActor () -> Date = Date.init
     ) {
         self.id = id
         self.name = name
         self.client = client
         self.initialRetryDelay = initialRetryDelay
         self.maxRetryDelay = maxRetryDelay
+        self.minimumRefreshInterval = minimumRefreshInterval
+        self.currentDate = currentDate
     }
 
     /// Connect to the bridge: fetch all data and start event stream
@@ -55,6 +69,7 @@ final class BridgeConnection: Identifiable {
         reconnectTask?.cancel()
         reconnectTask = nil
         status = .connecting
+        markFetchAllAttempt()
         await client.fetchAll()
         if let error = client.lastError {
             status = .error(error)
@@ -63,6 +78,19 @@ final class BridgeConnection: Identifiable {
             status = .connected
             retryAttempt = 0
             client.startEventStream()
+        }
+    }
+
+    /// Refresh bridge state even when the bridge is already connected.
+    func refresh() async {
+        guard status != .connecting, shouldStartRefresh() else { return }
+        switch status {
+        case .connected:
+            await refreshConnectedBridge()
+        case .disconnected, .error:
+            await connect()
+        case .connecting:
+            return
         }
     }
 
@@ -87,6 +115,30 @@ final class BridgeConnection: Identifiable {
             if delay >= maximum { return maximum }
         }
         return delay
+    }
+
+    private func refreshConnectedBridge() async {
+        reconnectTask?.cancel()
+        reconnectTask = nil
+        markFetchAllAttempt()
+        await client.fetchAll()
+        if let error = client.lastError {
+            status = .error(error)
+            client.stopEventStream()
+            scheduleReconnect()
+        } else {
+            status = .connected
+            retryAttempt = 0
+        }
+    }
+
+    private func shouldStartRefresh() -> Bool {
+        guard minimumRefreshInterval > 0, let lastFetchAllAttemptAt else { return true }
+        return currentDate().timeIntervalSince(lastFetchAllAttemptAt) >= minimumRefreshInterval
+    }
+
+    private func markFetchAllAttempt() {
+        lastFetchAllAttemptAt = currentDate()
     }
 
     private func scheduleReconnect() {

--- a/Sources/HueBar/Services/BridgeManager.swift
+++ b/Sources/HueBar/Services/BridgeManager.swift
@@ -5,6 +5,10 @@ import Foundation
 final class BridgeManager {
     private(set) var bridges: [BridgeConnection] = []
 
+    init(bridges: [BridgeConnection] = []) {
+        self.bridges = bridges
+    }
+
     /// Whether any bridge is currently loading
     var isLoading: Bool {
         bridges.contains { $0.status == .disconnected || $0.status == .connecting }
@@ -70,6 +74,13 @@ final class BridgeManager {
     func connectAll() async {
         for bridge in bridges {
             await bridge.connect()
+        }
+    }
+
+    /// Refresh all bridges, including bridges already marked connected.
+    func refreshAll() async {
+        for bridge in bridges {
+            await bridge.refresh()
         }
     }
 }

--- a/Sources/HueBar/Views/MenuBarView.swift
+++ b/Sources/HueBar/Views/MenuBarView.swift
@@ -10,6 +10,7 @@ struct MenuBarView: View {
     @State private var selectedZone: Zone?
     @State private var selectedClient: HueAPIClient?
     @State private var showSettings = false
+    @State private var refreshTask: Task<Void, Never>?
 
     /// The primary bridge client (first connected bridge)
     private var primaryClient: HueAPIClient? {
@@ -58,6 +59,15 @@ struct MenuBarView: View {
         .frame(width: 300, height: 550)
         .clipped()
         .preferredColorScheme(.dark)
+        .onAppear {
+            guard refreshTask == nil else { return }
+            refreshTask = Task {
+                await bridgeManager.refreshAll()
+                await MainActor.run {
+                    refreshTask = nil
+                }
+            }
+        }
     }
 
     // MARK: - Room List

--- a/Tests/HueBarTests/BridgeManagerTests.swift
+++ b/Tests/HueBarTests/BridgeManagerTests.swift
@@ -78,6 +78,7 @@ extension CredentialStoreTests {
     @Test func bridgeConnectionRetriesAfterTransientNetworkFailure() async throws {
         // Arrange
         let context = createRetryTestContext()
+        defer { BridgeConnectionRetryURLProtocol.requestHandler = nil }
 
         // Act
         await context.connection.connect()
@@ -96,6 +97,78 @@ extension CredentialStoreTests {
         #expect(context.requestCount() >= 10)
 
         context.connection.disconnect()
+    }
+
+    @Test func bridgeConnectionRefreshUpdatesConnectedBridgeState() async throws {
+        // Arrange
+        let context = createRefreshTestContext(groupedLightIsOn: true)
+        defer { BridgeConnectionRetryURLProtocol.requestHandler = nil }
+        context.connection.status = .connected
+        context.client.groupedLights = [
+            GroupedLight(id: "gl-1", on: OnState(on: false), dimming: DimmingState(brightness: 0), colorTemperature: nil),
+        ]
+
+        // Act
+        await context.connection.refresh()
+
+        // Assert
+        #expect(context.connection.status == .connected)
+        #expect(context.client.groupedLights.first?.isOn == true)
+        #expect(context.client.groupedLights.first?.brightness == 75)
+        #expect(context.requestCount() == 5)
+    }
+
+    @Test func bridgeConnectionRefreshSkipsConnectedBridgeWithinCooldown() async throws {
+        // Arrange
+        var currentDate = Date(timeIntervalSince1970: 100)
+        let context = createRefreshTestContext(
+            groupedLightIsOn: true,
+            minimumRefreshInterval: 30,
+            currentDate: { currentDate }
+        )
+        defer { BridgeConnectionRetryURLProtocol.requestHandler = nil }
+        context.connection.status = .connected
+        context.client.groupedLights = [
+            GroupedLight(id: "gl-1", on: OnState(on: false), dimming: DimmingState(brightness: 0), colorTemperature: nil),
+        ]
+
+        // Act
+        await context.connection.refresh()
+        context.client.groupedLights = [
+            GroupedLight(id: "gl-1", on: OnState(on: false), dimming: DimmingState(brightness: 0), colorTemperature: nil),
+        ]
+        currentDate = Date(timeIntervalSince1970: 110)
+        await context.connection.refresh()
+        let requestCountAfterCooldownSkip = context.requestCount()
+        let isOnAfterCooldownSkip = context.client.groupedLights.first?.isOn
+        currentDate = Date(timeIntervalSince1970: 131)
+        await context.connection.refresh()
+
+        // Assert
+        #expect(requestCountAfterCooldownSkip == 5)
+        #expect(isOnAfterCooldownSkip == false)
+        #expect(context.connection.status == .connected)
+        #expect(context.client.groupedLights.first?.isOn == true)
+        #expect(context.client.groupedLights.first?.brightness == 75)
+        #expect(context.requestCount() == 10)
+    }
+
+    @Test func bridgeManagerRefreshAllRefreshesConnectedBridges() async throws {
+        // Arrange
+        let context = createRefreshTestContext(groupedLightIsOn: true)
+        defer { BridgeConnectionRetryURLProtocol.requestHandler = nil }
+        context.connection.status = .connected
+        context.client.groupedLights = [
+            GroupedLight(id: "gl-1", on: OnState(on: false), dimming: DimmingState(brightness: 0), colorTemperature: nil),
+        ]
+        let manager = BridgeManager(bridges: [context.connection])
+
+        // Act
+        await manager.refreshAll()
+
+        // Assert
+        #expect(context.client.groupedLights.first?.isOn == true)
+        #expect(context.requestCount() == 5)
     }
 
     @Test func bridgeConnectionRetryDelayDoublesThenCaps() {
@@ -119,24 +192,46 @@ extension CredentialStoreTests {
         )
     }
 
+    private func createRefreshTestContext(
+        groupedLightIsOn: Bool,
+        minimumRefreshInterval: TimeInterval = 30,
+        currentDate: @escaping @MainActor () -> Date = Date.init
+    ) -> (
+        connection: BridgeConnection,
+        client: HueAPIClient,
+        requestCount: () -> Int
+    ) {
+        createBridgeConnectionContext { request, _ in
+            let path = request.url?.path ?? ""
+            let json: String
+            if path.hasSuffix("/room") {
+                json = #"{"errors":[],"data":[{"id":"room-1","metadata":{"name":"Office","archetype":"office"},"services":[{"rid":"gl-1","rtype":"grouped_light"}],"children":[]}]}"#
+            } else if path.hasSuffix("/grouped_light") {
+                json = #"{"errors":[],"data":[{"id":"gl-1","on":{"on":\#(groupedLightIsOn)},"dimming":{"brightness":75.0}}]}"#
+            } else {
+                json = #"{"errors":[],"data":[]}"#
+            }
+
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (response, Data(json.utf8))
+        } makeConnection: { client in
+            BridgeConnection(
+                id: "office-bridge",
+                name: "Office Bridge",
+                client: client,
+                initialRetryDelay: .milliseconds(10),
+                minimumRefreshInterval: minimumRefreshInterval,
+                currentDate: currentDate
+            )
+        }
+    }
+
     private func createRetryTestContext() -> (
         connection: BridgeConnection,
         client: HueAPIClient,
         requestCount: () -> Int
     ) {
-        let config = URLSessionConfiguration.ephemeral
-        config.protocolClasses = [BridgeConnectionRetryURLProtocol.self]
-        let session = URLSession(configuration: config)
-        let client = HueAPIClient(bridgeIP: "127.0.0.1:1234", applicationKey: "test-key", session: session)
-
-        let lock = NSLock()
-        var requestCount = 0
-        BridgeConnectionRetryURLProtocol.requestHandler = { request in
-            lock.lock()
-            requestCount += 1
-            let currentRequestCount = requestCount
-            lock.unlock()
-
+        createBridgeConnectionContext { request, currentRequestCount in
             if currentRequestCount <= 5 {
                 throw URLError(.notConnectedToInternet)
             }
@@ -154,8 +249,33 @@ extension CredentialStoreTests {
             let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
             return (response, Data(json.utf8))
         }
+    }
 
-        let connection = BridgeConnection(
+    private func createBridgeConnectionContext(
+        handler: @escaping @Sendable (URLRequest, Int) throws -> (HTTPURLResponse, Data),
+        makeConnection: ((HueAPIClient) -> BridgeConnection)? = nil
+    ) -> (
+        connection: BridgeConnection,
+        client: HueAPIClient,
+        requestCount: () -> Int
+    ) {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [BridgeConnectionRetryURLProtocol.self]
+        let session = URLSession(configuration: config)
+        let client = HueAPIClient(bridgeIP: "127.0.0.1:1234", applicationKey: "test-key", session: session)
+
+        let lock = NSLock()
+        var requestCount = 0
+        BridgeConnectionRetryURLProtocol.requestHandler = { request in
+            lock.lock()
+            requestCount += 1
+            let currentRequestCount = requestCount
+            lock.unlock()
+
+            return try handler(request, currentRequestCount)
+        }
+
+        let connection = makeConnection?(client) ?? BridgeConnection(
             id: "office-bridge",
             name: "Office Bridge",
             client: client,


### PR DESCRIPTION
HueBar could show stale light state after sitting idle if the SSE stream missed an update. This keeps SSE as the normal background path, but also refreshes bridge state when the menu opens so the UI has a fresh snapshot before you interact with it.

This PR:
- refreshes all bridges when the menu view appears
- refreshes already-connected bridges instead of skipping them
- adds a 30 second per-bridge cooldown so repeated menu opens don't spam `fetchAll()`
- uses the existing reconnect path if a refresh fails
- adds tests for connected refreshes, multi-bridge refresh, and the cooldown